### PR TITLE
created dir if non-existent

### DIFF
--- a/ui/main/settings.py
+++ b/ui/main/settings.py
@@ -11,12 +11,18 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 FILE_UPLOAD_HANDLERS = ["main.upload_handler.CustomFileUploadHandler"]
+
 FILE_UPLOAD_TEMP_DIR = BASE_DIR / "uploads"
+if not os.path.exists(FILE_UPLOAD_TEMP_DIR):
+    print("creating nonexistent", FILE_UPLOAD_TEMP_DIR)
+    os.makedirs(FILE_UPLOAD_TEMP_DIR)
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
 


### PR DESCRIPTION
error when starting project if FILE_UPLOAD_TEMP_DIR not existent
```
Watching for file changes with StatReloader
Performing system checks...

Exception in thread django-main-thread:
Traceback (most recent call last):
  File "C:\PrivatePath\anaconda3\envs\pz\Lib\threading.py", line 1038, in _bootstrap_inner
    self.run()
  File "C:\PrivatePath\anaconda3\envs\pz\Lib\threading.py", line 975, in run
    self._target(*self._args, **self._kwargs)
  File "C:\PrivatePath\anaconda3\envs\pz\Lib\site-packages\django\utils\autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "C:\PrivatePathl\anaconda3\envs\pz\Lib\site-packages\django\core\management\commands\runserver.py", line 134, in inner_run
    self.check(display_num_errors=True)
  File "C:\PrivatePath\anaconda3\envs\pz\Lib\site-packages\django\core\management\base.py", line 546, in check
    raise SystemCheckError(msg)
django.core.management.base.SystemCheckError: SystemCheckError: System check identified some issues:

ERRORS:
?: (files.E001) The FILE_UPLOAD_TEMP_DIR setting refers to the nonexistent directory 'C:\PathToPROTzilla\PROTzilla2\ui\uploads'.

```

## PR checklist

- [x] main-branch has been merged into local branch to resolve conflicts
- [ ] tests and linter have passed AFTER local merge
- [ ] at least one other dev reviewed and approved
- [x] documentation
- [x] tests
