### PR TITLE
Fix dynamic trigger

### DIFF
--- a/ui/runs/templates/runs/details.html
+++ b/ui/runs/templates/runs/details.html
@@ -22,6 +22,8 @@
                         csrfmiddlewaretoken: $('input[name=csrfmiddlewaretoken]').val(),
                     },
                     success: function (response) {
+                        $("#method_parameters").empty();
+                        $("#plot_parameters").empty();
                         $("#method_parameters").html(response.parameters);
                         $("#plot_parameters").html(response.plot_parameters);
                     }
@@ -52,7 +54,7 @@
                 })
             });
 
-            $(".dynamic_trigger").change(function () {
+            $("#method_parameters").on("change", ".dynamic_trigger", function () {
                 const selected_choice = $(this).val();
                 const triggered_id = $(this).attr("id");
 
@@ -66,6 +68,7 @@
                     },
                     success: function (response) {
                         $.each(response, function (key, value) {
+                            $('#' + key).empty();
                             $('#' + key).html(value);
                         })
                     }


### PR DESCRIPTION
The dynamic trigger class is used on fields that trigger other fields to change when they are changed e.g. the grouping parameter in t-test and anova. 

This was not working before after the method of a step was changed dynamically (via the dropdown). The reason for this is that jQuery has already assigned event handlers when the new html is added, so the new html does not trigger our code. We can fix this by using Event Propagation (https://learn.jquery.com/events/event-delegation/).

I also added the `.empty()` statement in some places because it is generally better to make sure the old html is gone before we insert the new html.

## PR checklist

- [x] main-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [ ] at least one other dev reviewed and approved
