### PR TITLE
Display messages instead of raising errors.

### DIFF
--- a/protzilla/importing/metadata_import.py
+++ b/protzilla/importing/metadata_import.py
@@ -1,6 +1,7 @@
 import os
 
 import pandas as pd
+from django.contrib import messages
 
 from protzilla.constants.paths import PROJECT_PATH
 from protzilla.utilities.random import random_string
@@ -22,10 +23,18 @@ def metadata_import_method(df, file_path, feature_orientation):
         meta_df = pd.read_csv(file_path, sep="|", low_memory=False)
     elif file_path.endswith(".tsv"):
         meta_df = pd.read_csv(file_path, sep="\t", low_memory=False)
+    elif file_path == "":
+        msg = "The file upload is empty. Please select a metadata file."
+        return df, dict(
+            meta_df=None,
+            messages=[dict(level=messages.ERROR, msg=msg)],
+        )
     else:
-        raise TypeError(
-            "File format not supported. \
+        msg = "File format not supported. \
         Supported file formats are csv, xlsx, psv or tsv"
+        return df, dict(
+            meta_df=None,
+            messages=[dict(level=messages.ERROR, msg=msg)],
         )
 
     # always return metadata in the same orientation (features as columns)

--- a/protzilla/importing/ms_data_import.py
+++ b/protzilla/importing/ms_data_import.py
@@ -1,11 +1,17 @@
 from pathlib import Path
 
 import pandas as pd
+from django.contrib import messages
 
 
 def max_quant_import(_, file_path, intensity_name):
     assert intensity_name in ["Intensity", "iBAQ", "LFQ intensity"]
-    assert Path(file_path).is_file()
+    if not Path(file_path).is_file():
+        msg = "The file upload is empty. Please provide a Max Quant file."
+        return None, dict(
+            meta_df=None,
+            messages=[dict(level=messages.ERROR, msg=msg)],
+        )
     selected_columns = ["Protein IDs", "Gene names"]
     read = pd.read_csv(
         file_path,
@@ -42,7 +48,12 @@ def ms_fragger_import(_, file_path, intensity_name):
         "Spectral Count",
         "Total Spectral Count",
     ]
-    assert Path(file_path).is_file()
+    if not Path(file_path).is_file():
+        msg = "The file upload is empty. Please provide a MS Fragger file."
+        return None, dict(
+            meta_df=None,
+            messages=[dict(level=messages.ERROR, msg=msg)],
+        )
     selected_columns = ["Protein ID", "Gene"]
     read = pd.read_csv(
         file_path,

--- a/ui/runs/views.py
+++ b/ui/runs/views.py
@@ -3,7 +3,6 @@ import tempfile
 import traceback
 import zipfile
 
-import plotly.graph_objs as go
 from django.contrib import messages
 from django.http import FileResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import render
@@ -11,10 +10,7 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from main.settings import BASE_DIR
 
-from protzilla.workflow_helper import get_workflow_default_param_value
-
 sys.path.append(f"{BASE_DIR}/..")
-
 
 from protzilla.run import Run
 from ui.runs.fields import (


### PR DESCRIPTION


Description (what might a Reviewer want to know)
When the file upload during importing stays empty, a message is displayed to prevent an error and the ugly yellow page.

## PR checklist

- [x] main-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [ ] at least one other dev reviewed and approved
- [ ] documentation
- [ ] tests
