### PR TITLE
add logger for protzilla, django

### DIFF
--- a/protzilla/constants/logging.py
+++ b/protzilla/constants/logging.py
@@ -9,6 +9,7 @@ class ProtzillaLoggingHandler(logging.Handler):
                 https://stackoverflow.com/a/56944256/1435167
 
     A logging handler that emits styled log messages to the console.
+    Used by the protzilla app and as the Django logging handler.
     """
 
     def __init__(self, level=logging.NOTSET):
@@ -66,9 +67,11 @@ class ProtzillaLoggingHandler(logging.Handler):
 # the logger used by DJANGO is configured in ui/main/settings.py::LOGGING
 
 # this logger is/can be used by the protzilla app
+# adjust `protzilla_logging_level` to adjust the verbosity of the protzilla logger
+protzilla_logging_level = logging.INFO
 logger = logging.getLogger("protzilla")
-logger.setLevel(logging.INFO)
-logger.addHandler(ProtzillaLoggingHandler(logging.INFO))
+logger.setLevel(protzilla_logging_level)
+logger.addHandler(ProtzillaLoggingHandler(protzilla_logging_level))
 
 MESSAGE_TO_LOGGING_FUNCTION = {
     messages.ERROR: logging.error,

--- a/ui/main/settings.py
+++ b/ui/main/settings.py
@@ -134,6 +134,8 @@ STATICFILES_DIRS = [BASE_DIR / "static"]
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+# This configures the django logger
+# to adjust the protzilla-logger, see protzilla.constants.logging for more info
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,


### PR DESCRIPTION
This PR adds a logger that can be easily imported anywhere in portzilla using `from protzilla.constants.logging import logger` and can be used by calling `logger.debug()`, `logger.info()`, `logger.warning()`, `logger.error()`, `logger.critical()`.

The logger is configured with level INFO so only `info` and more severe messages will be logged. That way we can leave useful debugging messages in the code and when we need them, set the logger to DEBUG so they will be printed as well.

messages are color-coded and the level-indicator is fixed with to easily pick out messages of different severity-levels.

In general, as the project will go public eventually, we should leave professionalize our logging behaviour a bit, IMO according to the [python docs](https://docs.python.org/3/howto/logging.html).

## PR checklist

- [x] main-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] at least one other dev reviewed and approved
- [x] documentation -> [wiki -> logging -> console logging](https://github.com/antonneubauer/PROTzilla2/wiki/Error-Handling-and-Logging)
~~tests~~
