### PR TITLE
omit tests/* in test coverage calculation

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [coverage:run]
 relative_files = True
-omit = user_data/*, db.sqlite3, constants/*, 
+omit = user_data/*, db.sqlite3, constants/*, tests/*


### PR DESCRIPTION
The tests/* files shouldn't be included in the test-coverage calculation as they are not what is tested

## PR checklist

- [x] main-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [ ] at least one other dev reviewed and approved
