### PR TITLE
Implement download for base64 plots

### DIFF
--- a/protzilla/run.py
+++ b/protzilla/run.py
@@ -1,6 +1,6 @@
+import base64
 import json
 import shutil
-import base64
 import traceback
 from io import BytesIO
 from pathlib import Path
@@ -386,10 +386,10 @@ class Run:
                 else:
                     binary_string = plotly.io.to_image(plot, format=format_, scale=4)
                     exports.append(BytesIO(binary_string))
-            elif isinstance(plot, dict) and "plot_base64" in plot: # catch dicts
+            elif isinstance(plot, dict) and "plot_base64" in plot:
                 plot = plot["plot_base64"]
 
-            if isinstance(plot, bytes): # bytes are base64 encoded
+            if isinstance(plot, bytes):  # base64 encoded plots
                 if format_ in ["eps", "tiff"]:
                     img = Image.open(BytesIO(base64.b64decode(plot))).convert("RGB")
                     binary = BytesIO()

--- a/tests/protzilla/test_run.py
+++ b/tests/protzilla/test_run.py
@@ -1,10 +1,11 @@
 import json
 from shutil import rmtree
 
+import pandas as pd
 import pytest
 from PIL import Image
 
-from protzilla import data_preprocessing
+from protzilla import data_integration, data_preprocessing
 from protzilla.constants.paths import PROJECT_PATH, RUNS_PATH
 from protzilla.importing import ms_data_import
 from protzilla.run import Run
@@ -253,6 +254,33 @@ def test_export_plot(tests_folder_name):
         dict(graph_type="Boxplot", graph_type_quantites="Bar chart", group_by="Sample"),
     )
     assert len(run.plots) > 1
+    for plot in run.export_plots("tiff"):
+        Image.open(plot).verify()
+    for plot in run.export_plots("eps"):
+        Image.open(plot).verify()
+
+
+def test_export_plot_base64(tests_folder_name):
+    run_name = tests_folder_name + "/test_export_plot_" + random_string()
+    input_df_path = (
+        PROJECT_PATH
+        / "tests/test_data/enrichment_data"
+        / "Reactome_enrichment_enrichr.csv"
+    )
+
+    run = Run.create(run_name)
+    run.create_step_plot(
+        data_integration.di_plots.go_enrichment_bar_plot,
+        dict(
+            input_df=pd.read_csv(input_df_path, sep="\t"),
+            categories=["Reactome_2013"],
+            top_terms=10,
+            cutoff=0.05,
+            value="p_value",
+        ),
+    )
+    for plot in run.export_plots("png"):
+        Image.open(plot).verify()
     for plot in run.export_plots("tiff"):
         Image.open(plot).verify()
     for plot in run.export_plots("eps"):

--- a/ui/runs/views.py
+++ b/ui/runs/views.py
@@ -1,8 +1,8 @@
+import base64
 import sys
 import tempfile
 import traceback
 import zipfile
-import base64
 from pathlib import Path
 
 import networkx as nx


### PR DESCRIPTION
- fixes #262 

## Description
- implements download for base64 plots
- formats: png, jpg, tiff, eps
- I tried to get svg and pdf download to work with cairosvg and pyvips but the installation of the packages would not work with PROTzilla. Maybe we can add this functionality later using a different approach.
- I also fixed the download of zipped files for windows, which didn't work

## PR checklist

- [x] main-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [ ] at least one other dev reviewed and approved
- [x] documentation
- [x] tests
