### PR TITLE
test_create_histograms tests the right Method now

### DIFF
--- a/tests/protzilla/data_preprocessing/test_plots_data_preprocessing.py
+++ b/tests/protzilla/data_preprocessing/test_plots_data_preprocessing.py
@@ -93,11 +93,10 @@ def test_create_histograms(
 
     # should throw Value Error
     with pytest.raises(ValueError):
-        # TODO: 304
-        create_box_plots(
+        create_histograms(
             dataframe_a=input_imputation_df,
             dataframe_b=assertion_df_knn,
-            group_by="wrong_group_by",
+            visual_transformation="wrong_visual_transformation",
         )
     return
 


### PR DESCRIPTION
- fixes #304

Description (what might a Reviewer want to know)
 - in test_plots_data_preprocessing.py the Test test_create_histograms called tested the Method create_box_plot. This was most likely  just a coppy-paste-error since the test_box_plot method just above had nearly identical code. This was corrected.

## PR checklist

- [ ] main-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] at least one other dev reviewed and approved
- [x] documentation
- [x] tests
