### PR TITLE
Removed "label" from pie chart when hovering

### DIFF
--- a/protzilla/data_preprocessing/plots.py
+++ b/protzilla/data_preprocessing/plots.py
@@ -49,6 +49,7 @@ def create_pie_plot(
         },
         font=dict(size=14, family="Arial"),
     )
+    fig.update_traces(hovertemplate="%{label} <br>Amount: %{value}")
     return fig
 
 


### PR DESCRIPTION
- fixes #321 

Description (what might a Reviewer want to know)
  - i added one line that updates the hover labels plots.py
  - test with creating a pie chart and hover over

## PR checklist

- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] tests and linter have passed AFTER local merge
- [x] at least one other dev reviewed and approved
- [x] documentation
- [x] tests
