### PR TITLE
Add caching for python dependencies in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,15 @@ jobs:
         with:
           python-version: "3.11"
       
+      - name: Cache Python dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            !~/.cache/pip/log
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
- fixes (in part) the runtime of the ci on github, saving some 15 odd seconds of installing libraries using pip

- this particular change adds a step called "cache python dependencies", which on the first run (as seen here) doesn't find the cached dependencies, but on a re-run uses the previously downloaded deps
- the cache is updated, whenever the (hash of) requirements.txt changes, which is quite rare.
## PR checklist

- [x] main-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] at least one other dev reviewed and approved
- [x] documentation
- [x] tests
