### PR TITLE
Changed a parameter description for t-test

### DIFF
--- a/protzilla/constants/workflow_meta.json
+++ b/protzilla/constants/workflow_meta.json
@@ -978,7 +978,7 @@
             "default": 0
           },
           "log_base": {
-            "name": "base of log transformation (leave empty if no log transformation was performed on the data)",
+            "name": "base of log transformation",
             "type": "numeric",
             "min": 2,
             "default": null


### PR DESCRIPTION
- fixes #284

You need to do t-test before you plot the volcano graph. 

## PR checklist

- [x] main-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [ ] at least one other dev reviewed and approved
- [x] documentation
- [x] tests
