### PR TITLE
347 add disclaimer regarding clicking back button in the browser

### DIFF
--- a/ui/runs/templates/runs/details.html
+++ b/ui/runs/templates/runs/details.html
@@ -259,16 +259,15 @@
                                                         <h5 class="modal-title" id="calculationInProgressModalLabel">Do you want back?</h5>
                                                     </div>
                                                     <div class="modal-body">
-                                                        <!-- You can add additional content or messages here -->
                                                         Going a step back during calculation may lead to unforseen behavior and loss in data.
-                                                        Do you want to go ahead?
+                                                        Do you want to proceed?
                                                         <hr>
-                                                        <a href="{% url 'runs:back' run_name %}" id = "backButton2" class="btn btn-red mr-auto">Back</a>
-                                                        <button id = "cancel" class="btn btn-grey mr-auto">Cancel
-                                                    </div>
+                                                        <a href="{% url 'runs:back' run_name %}" id = "backButton" class="btn btn-red mr-auto">Back</a>
+                                                        <button id= "cancel" type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
                                                 </div>
                                             </div>
                                         </div>
+                                    </div>
                                     {% endif %}
                                     <button class="btn btn-red" {% if not show_next %} disabled {% endif %}>Next
                                     </button>
@@ -280,4 +279,5 @@
             </div>
         </div>
     </div>
-{% endblock %}
+
+    {% endblock %}

--- a/ui/runs/templates/runs/form_buttons.html
+++ b/ui/runs/templates/runs/form_buttons.html
@@ -151,9 +151,9 @@
             if (calculationInProgress) {
                 event.preventDefault();
                 showCalculationInProgressModal();
-                $('#cancel').click(function() {
+                $('#cancel').click(function () {
                     hideCalculationInProgressModal();
-        });
+            });
     }
     });
         if($('#plot_form').find('input').length) {


### PR DESCRIPTION
- fixes #347
Description (what might a Reviewer want to know)
i added a pop up window that is shown when something in the preprocessing step is calculated and during this, back is clicked. the user can decide to still go back, with the risk of breaking the run. or they can safely return to the calculation with cancel.

this can best be tested with the following code:

        setTimeout(function () {
            console.log("Executed after 10 seconds");
            console.log("flag is false");
            calculationInProgress = false;
            }, 10000);

added at 182 and with the line 183 in form_buttons.html commented out. Usually, the calculation duration is to short to press back so for test purposes a delay is added.


## PR checklist

- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] tests and linter have passed AFTER local merge
- [ ] at least one other dev reviewed and approved
- [ ] documentation
- [ ] tests
