### PR TITLE
only drop columns in data frame if they exist

### DIFF
--- a/protzilla/importing/ms_data_import.py
+++ b/protzilla/importing/ms_data_import.py
@@ -62,13 +62,17 @@ def ms_fragger_import(
             keep_default_na=True,
         )
         protein_groups = df["Protein ID"]
-        df = df.drop(
-            columns=[
-                "Combined Spectral Count",
-                "Combined Unique Spectral Count",
-                "Combined Total Spectral Count",
-            ]
-        )
+        columns_to_drop = [
+            "Combined Spectral Count",
+            "Combined Unique Spectral Count",
+            "Combined Total Spectral Count",
+        ]
+        existing_columns = set(df.columns)
+        columns_to_drop_existing = [
+            col for col in columns_to_drop if col in existing_columns
+        ]
+        df = df.drop(columns=columns_to_drop_existing)
+
         intensity_df = df.filter(regex=f"{intensity_name}$", axis=1)
         intensity_df.columns = [
             c[: -(len(intensity_name) + 1)] for c in intensity_df.columns


### PR DESCRIPTION
- fixes #375 

Description (what might a Reviewer want to know)
-added if condition to check wether the columns that need to be dropped exist in specific msfragger file. 
-go through workflow and check whether msfragger import (please check both msfragger files in nextcloud) and all plots work as they should
(also, in protquant plot, there is only 1 group; i have noticed this, but it seems to be no problem coming directly from msfragger data)

## PR checklist

- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] tests and linter have passed AFTER local merge
- [ ] at least one other dev reviewed and approved
- [ ] documentation
- [ ] tests
