### PR TITLE
Fix bug in plot of log transformation

### DIFF
--- a/protzilla/constants/workflow_meta.json
+++ b/protzilla/constants/workflow_meta.json
@@ -537,7 +537,7 @@
                 "linear",
                 "log10"
               ],
-              "default": "linear"
+              "default": "log10"
             }
           },
           {

--- a/protzilla/data_preprocessing/plots.py
+++ b/protzilla/data_preprocessing/plots.py
@@ -252,27 +252,28 @@ def create_histograms(
     min_value = min(intensities_a.min(skipna=True), intensities_b.min(skipna=True))
     max_value = max(intensities_a.max(skipna=True), intensities_b.max(skipna=True))
 
-    binsize_factor = 0.0005 if visual_transformation == "linear" else 0.02
+    number_of_bins = 100
+    binsize_a = (
+        intensities_a.max(skipna=True) - intensities_a.min(skipna=True)
+    ) / number_of_bins
+    binsize_b = (
+        intensities_b.max(skipna=True) - intensities_b.min(skipna=True)
+    ) / number_of_bins
+
+    if overlay:
+        binsize_a = binsize_b = max(binsize_a, binsize_b)
 
     trace0 = go.Histogram(
         x=intensities_a,
         marker_color=PROTZILLA_DISCRETE_COLOR_SEQUENCE[0],
         name=name_a,
-        xbins=dict(
-            start=min_value,
-            end=max_value,
-            size=(max_value - min_value) * binsize_factor,
-        ),
+        xbins=dict(start=min_value, end=max_value, size=binsize_a),
     )
     trace1 = go.Histogram(
         x=intensities_b,
         marker_color=PROTZILLA_DISCRETE_COLOR_SEQUENCE[1],
         name=name_b,
-        xbins=dict(
-            start=min_value,
-            end=max_value,
-            size=(max_value - min_value) * binsize_factor,
-        ),
+        xbins=dict(start=min_value, end=max_value, size=binsize_b),
     )
     if not overlay:
         fig = make_subplots(rows=1, cols=2)


### PR DESCRIPTION
- fix #415 

Description (what might a Reviewer want to know)
Only reworked the way the bin sizes are set, by default the range is divided into 100 bins, and when two datasets are present that should be overlayed, the bigger binsize is chosen for both plots, for visual coherence and clarity.

## PR checklist

- [x] main-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] at least one other dev reviewed and approved
