### PR TITLE
fix check of class

### DIFF
--- a/protzilla/run.py
+++ b/protzilla/run.py
@@ -288,7 +288,7 @@ class Run:
                 self.df, self.result_df, self.current_out, **parameters
             )
             for plot in self.plots:
-                if plot is dict and "messages" in plot:
+                if isinstance(plot, dict) and "messages" in plot:
                     self.current_messages.extend(plot["messages"])
                     self.plots.remove(plot)
 
@@ -317,7 +317,7 @@ class Run:
             self.calculated_method = self.method
 
             for plot in self.plots:
-                if plot is dict and "messages" in plot:
+                if isinstance(plot, dict) and "messages" in plot:
                     self.current_messages.extend(plot["messages"])
                     self.plots.remove(plot)
         except Exception as e:


### PR DESCRIPTION
fixes #480

- to extract the message dict from the plot it is necessary to check if the element is a dict in order to differentiate between message dicts and plots
- this check did not function propperly and was fixed with this PR

## PR checklist

- [x] main-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [ ] at least one other dev reviewed and approved