### PR TITLE
changed order in standard workflow

### DIFF
--- a/user_data/workflows/standard.json
+++ b/user_data/workflows/standard.json
@@ -70,19 +70,6 @@
           }
         },
         {
-          "name": "transformation",
-          "method": "log_transformation",
-          "parameters": {
-            "log_base": "log2"
-          },
-          "graphs": [
-            {
-              "graph_type": "Boxplot",
-              "group_by": "Sample"
-            }
-          ]
-        },
-        {
           "name": "normalisation",
           "method": "median",
           "parameters": {
@@ -95,6 +82,19 @@
             }
           ],
             "output_name": "preprocessed_data"
+        },
+        {
+          "name": "transformation",
+          "method": "log_transformation",
+          "parameters": {
+            "log_base": "log2"
+          },
+          "graphs": [
+            {
+              "graph_type": "Boxplot",
+              "group_by": "Sample"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
## Description
fixes #425 
- the order of standard workflow was changed this effected the volcano plot as follows 
- before:
![Screenshot 2024-02-21 at 15-04-43 PROTzilla - transform_normalize](https://github.com/cschlaffner/PROTzilla2/assets/50395935/ef3fad04-987a-44db-af58-671433742f7c)
- current:
![Screenshot 2024-02-21 at 15-08-32 PROTzilla - normalize_transform](https://github.com/cschlaffner/PROTzilla2/assets/50395935/372f3995-d1d3-4e4b-8f8f-522d26d1ef9d)
- without normalization: 
![Screenshot 2024-02-21 at 15-35-49 PROTzilla - no_normalisation](https://github.com/cschlaffner/PROTzilla2/assets/50395935/b5d91a6b-dc11-4796-8b10-9012a79e2958)

## Changes
- all changes are in standard.json the order of transformation and normalization was swapped


## Testing
- open and klick through the standard workflow
- perform t-test and volcano plot in data analysis to evaluate the quality of the Plot

## PR checklist
**Development**
- ~~[ ] If necessary, I have updated the documentation (README, docstrings, etc.)~~
- ~~[ ] If necessary, I have created / updated tests.~~

 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The code has been formatted with `black`
 
**Code review**
- [x] I have self-reviewed my code.
- [x] At least one other developer reviewed and approved the changes
