### PR TITLE
adapt step size

### DIFF
--- a/protzilla/constants/workflow_meta.json
+++ b/protzilla/constants/workflow_meta.json
@@ -1229,6 +1229,7 @@
             "type": "numeric",
             "min": -1,
             "max": 999,
+            "step": 0.1,
             "default": 1
           }
         }


### PR DESCRIPTION
## Description
fixes #345 
- in Data Analysis, Plot, Prot Quant, the field similarity is increased in steps of 0.1 

## Changes
- all changes are in workflow meta, where the parameter step was added to the respective method

## Testing
- step through the standard workflow to the Prot Quant Plot and change the similarity using the little arrows on the right end of this field .

**Development**
- ~~[ ] If necessary, I have updated the documentation (README, docstrings, etc.)~~
- ~~[ ] If necessary, I have created / updated tests.~~
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The code has been formatted with `black`
 
**Code review**
- [x] I have self-reviewed my code.
- [x] At least one other developer reviewed and approved the changes
