### PR TITLE
Restructured box plot grouping

### DIFF
--- a/protzilla/constants/workflow_meta.json
+++ b/protzilla/constants/workflow_meta.json
@@ -365,7 +365,7 @@
               "default": "None"
             },
             "proteins_of_interest": {
-              "name": "Proteins of interest",
+              "name": "Proteins of interest (Only for Boxplot)",
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
@@ -403,7 +403,7 @@
               "default": "None"
             },
             "proteins_of_interest": {
-              "name": "Proteins of interest",
+              "name": "Proteins of interest (Only for Boxplot)",
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
@@ -439,7 +439,7 @@
               "default": "None"
             },
             "proteins_of_interest": {
-              "name": "Proteins of interest",
+              "name": "Proteins of interest (Only for Boxplot)",
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
@@ -484,7 +484,7 @@
               "default": "None"
             },
             "proteins_of_interest": {
-              "name": "Proteins of interest",
+              "name": "Proteins of interest (Only for Boxplot)",
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
@@ -527,7 +527,7 @@
               "default": "None"
             },
             "proteins_of_interest": {
-              "name": "Proteins of interest",
+              "name": "Proteins of interest (Only for Boxplot)",
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
@@ -573,7 +573,7 @@
               "default": "None"
             },
             "proteins_of_interest": {
-              "name": "Proteins of interest",
+              "name": "Proteins of interest (Only for Boxplot)",
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
@@ -637,7 +637,7 @@
               "default": "None"
             },
             "proteins_of_interest": {
-              "name": "Proteins of interest",
+              "name": "Proteins of interest (Only for Boxplot)",
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
@@ -701,7 +701,7 @@
               "default": "None"
             },
             "proteins_of_interest": {
-              "name": "Proteins of interest",
+              "name": "Proteins of interest (Only for Boxplot)",
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
@@ -768,7 +768,7 @@
               "default": "None"
             },
             "proteins_of_interest": {
-              "name": "Proteins of interest",
+              "name": "Proteins of interest (Only for Boxplot)",
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
@@ -832,7 +832,7 @@
               "default": "None"
             },
             "proteins_of_interest": {
-              "name": "Proteins of interest",
+              "name": "Proteins of interest (Only for Boxplot)",
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
@@ -912,7 +912,7 @@
               "default": "None"
             },
             "proteins_of_interest": {
-              "name": "Proteins of interest",
+              "name": "Proteins of interest (Only for Boxplot)",
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],

--- a/protzilla/constants/workflow_meta.json
+++ b/protzilla/constants/workflow_meta.json
@@ -369,7 +369,7 @@
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
-              "default": null,
+              "default": [],
               "multiple": true
             }
           }
@@ -407,7 +407,7 @@
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
-              "default": null,
+              "default": [],
               "multiple": true
             }
           }
@@ -443,7 +443,7 @@
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
-              "default": null,
+              "default": [],
               "multiple": true
             }
           }
@@ -488,7 +488,7 @@
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
-              "default": null,
+              "default": [],
               "multiple": true
             }
           }
@@ -531,7 +531,7 @@
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
-              "default": null,
+              "default": [],
               "multiple": true
             }
           }
@@ -577,7 +577,7 @@
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
-              "default": null,
+              "default": [],
               "multiple": true
             },
             "visual_transformation": {
@@ -641,7 +641,7 @@
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
-              "default": null,
+              "default": [],
               "multiple": true
             },
             "visual_transformation": {
@@ -705,7 +705,7 @@
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
-              "default": null,
+              "default": [],
               "multiple": true
             },
             "visual_transformation": {
@@ -772,7 +772,7 @@
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
-              "default": null,
+              "default": [],
               "multiple": true
             },
             "visual_transformation": {
@@ -836,7 +836,7 @@
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
-              "default": null,
+              "default": [],
               "multiple": true
             },
             "visual_transformation": {
@@ -916,7 +916,7 @@
               "type": "categorical",
               "fill": "protein_group_column",
               "categories": [],
-              "default": null,
+              "default": [],
               "multiple": true
             },
             "visual_transformation": {

--- a/protzilla/constants/workflow_meta.json
+++ b/protzilla/constants/workflow_meta.json
@@ -363,6 +363,14 @@
                 "Protein ID"
               ],
               "default": "None"
+            },
+            "proteins_of_interest": {
+              "name": "Proteins of interest",
+              "type": "categorical",
+              "fill": "protein_group_column",
+              "categories": [],
+              "default": null,
+              "multiple": true
             }
           }
         ]
@@ -393,6 +401,14 @@
                 "Protein ID"
               ],
               "default": "None"
+            },
+            "proteins_of_interest": {
+              "name": "Proteins of interest",
+              "type": "categorical",
+              "fill": "protein_group_column",
+              "categories": [],
+              "default": null,
+              "multiple": true
             }
           }
         ]
@@ -421,6 +437,14 @@
                 "Protein ID"
               ],
               "default": "None"
+            },
+            "proteins_of_interest": {
+              "name": "Proteins of interest",
+              "type": "categorical",
+              "fill": "protein_group_column",
+              "categories": [],
+              "default": null,
+              "multiple": true
             }
           }
         ]
@@ -458,6 +482,14 @@
                 "Protein ID"
               ],
               "default": "None"
+            },
+            "proteins_of_interest": {
+              "name": "Proteins of interest",
+              "type": "categorical",
+              "fill": "protein_group_column",
+              "categories": [],
+              "default": null,
+              "multiple": true
             }
           }
         ]
@@ -493,6 +525,14 @@
                 "Protein ID"
               ],
               "default": "None"
+            },
+            "proteins_of_interest": {
+              "name": "Proteins of interest",
+              "type": "categorical",
+              "fill": "protein_group_column",
+              "categories": [],
+              "default": null,
+              "multiple": true
             }
           }
         ]
@@ -531,6 +571,14 @@
                 "Protein ID"
               ],
               "default": "None"
+            },
+            "proteins_of_interest": {
+              "name": "Proteins of interest",
+              "type": "categorical",
+              "fill": "protein_group_column",
+              "categories": [],
+              "default": null,
+              "multiple": true
             },
             "visual_transformation": {
               "name": "Visual transformation:",
@@ -588,6 +636,14 @@
               ],
               "default": "None"
             },
+            "proteins_of_interest": {
+              "name": "Proteins of interest",
+              "type": "categorical",
+              "fill": "protein_group_column",
+              "categories": [],
+              "default": null,
+              "multiple": true
+            },
             "visual_transformation": {
               "name": "Visual transformation:",
               "type": "categorical",
@@ -643,6 +699,14 @@
                 "Protein ID"
               ],
               "default": "None"
+            },
+            "proteins_of_interest": {
+              "name": "Proteins of interest",
+              "type": "categorical",
+              "fill": "protein_group_column",
+              "categories": [],
+              "default": null,
+              "multiple": true
             },
             "visual_transformation": {
               "name": "Visual transformation:",
@@ -703,6 +767,14 @@
               ],
               "default": "None"
             },
+            "proteins_of_interest": {
+              "name": "Proteins of interest",
+              "type": "categorical",
+              "fill": "protein_group_column",
+              "categories": [],
+              "default": null,
+              "multiple": true
+            },
             "visual_transformation": {
               "name": "Visual transformation:",
               "type": "categorical",
@@ -758,6 +830,14 @@
                 "Protein ID"
               ],
               "default": "None"
+            },
+            "proteins_of_interest": {
+              "name": "Proteins of interest",
+              "type": "categorical",
+              "fill": "protein_group_column",
+              "categories": [],
+              "default": null,
+              "multiple": true
             },
             "visual_transformation": {
               "name": "Visual transformation:",
@@ -830,6 +910,14 @@
                 "Protein ID"
               ],
               "default": "None"
+            },
+            "proteins_of_interest": {
+              "name": "Proteins of interest",
+              "type": "categorical",
+              "fill": "protein_group_column",
+              "categories": [],
+              "default": null,
+              "multiple": true
             },
             "visual_transformation": {
               "name": "Visual transformation:",

--- a/protzilla/data_analysis/plots.py
+++ b/protzilla/data_analysis/plots.py
@@ -64,9 +64,7 @@ def scatter_plot(
             fig = px.scatter_3d(
                 intensity_df_wide, x=x_name, y=y_name, z=z_name, color=color_name
             )
-            fig.update_traces(
-                marker_color=colors["annotation_proteins_of_interest"]
-            )
+            fig.update_traces(marker_color=colors["annotation_proteins_of_interest"])
         else:
             raise ValueError(
                 "The dimensions of the DataFrame are either too high or too low."

--- a/protzilla/data_preprocessing/imputation.py
+++ b/protzilla/data_preprocessing/imputation.py
@@ -362,15 +362,13 @@ def by_knn_plot(
     visual_transformation,
     proteins_of_interest=None,
 ):
-    if proteins_of_interest is None:
-        proteins_of_interest = []
     return _build_box_hist_plot(
         df,
         result_df,
         graph_type,
         graph_type_quantities,
         group_by,
-        proteins_of_interest,
+        [] if proteins_of_interest is None else proteins_of_interest,
         visual_transformation,
     )
 
@@ -385,15 +383,13 @@ def by_normal_distribution_sampling_plot(
     visual_transformation,
     proteins_of_interest=None,
 ):
-    if proteins_of_interest is None:
-        proteins_of_interest = []
     return _build_box_hist_plot(
         df,
         result_df,
         graph_type,
         graph_type_quantities,
         group_by,
-        proteins_of_interest,
+        [] if proteins_of_interest is None else proteins_of_interest,
         visual_transformation,
     )
 
@@ -408,15 +404,13 @@ def by_simple_imputer_plot(
     visual_transformation,
     proteins_of_interest=None,
 ):
-    if proteins_of_interest is None:
-        proteins_of_interest = []
     return _build_box_hist_plot(
         df,
         result_df,
         graph_type,
         graph_type_quantities,
         group_by,
-        proteins_of_interest,
+        [] if proteins_of_interest is None else proteins_of_interest,
         visual_transformation,
     )
 
@@ -431,15 +425,13 @@ def by_min_per_sample_plot(
     visual_transformation,
     proteins_of_interest=None,
 ):
-    if proteins_of_interest is None:
-        proteins_of_interest = []
     return _build_box_hist_plot(
         df,
         result_df,
         graph_type,
         graph_type_quantities,
         group_by,
-        proteins_of_interest,
+        [] if proteins_of_interest is None else proteins_of_interest,
         visual_transformation,
     )
 
@@ -454,15 +446,13 @@ def by_min_per_protein_plot(
     visual_transformation,
     proteins_of_interest=None,
 ):
-    if proteins_of_interest is None:
-        proteins_of_interest = []
     return _build_box_hist_plot(
         df,
         result_df,
         graph_type,
         graph_type_quantities,
         group_by,
-        proteins_of_interest,
+        [] if proteins_of_interest is None else proteins_of_interest,
         visual_transformation,
     )
 
@@ -477,15 +467,13 @@ def by_min_per_dataset_plot(
     visual_transformation,
     proteins_of_interest=None,
 ):
-    if proteins_of_interest is None:
-        proteins_of_interest = []
     return _build_box_hist_plot(
         df,
         result_df,
         graph_type,
         graph_type_quantities,
         group_by,
-        proteins_of_interest,
+        [] if proteins_of_interest is None else proteins_of_interest,
         visual_transformation,
     )
 

--- a/protzilla/data_preprocessing/imputation.py
+++ b/protzilla/data_preprocessing/imputation.py
@@ -359,9 +359,11 @@ def by_knn_plot(
     graph_type,
     graph_type_quantities,
     group_by,
-    proteins_of_interest,
     visual_transformation,
+    proteins_of_interest = None,
 ):
+    if proteins_of_interest is None:
+        proteins_of_interest = []
     return _build_box_hist_plot(
         df,
         result_df,
@@ -380,9 +382,11 @@ def by_normal_distribution_sampling_plot(
     graph_type,
     graph_type_quantities,
     group_by,
-    proteins_of_interest,
     visual_transformation,
+    proteins_of_interest = None,
 ):
+    if proteins_of_interest is None:
+        proteins_of_interest = []
     return _build_box_hist_plot(
         df,
         result_df,
@@ -401,9 +405,11 @@ def by_simple_imputer_plot(
     graph_type,
     graph_type_quantities,
     group_by,
-    proteins_of_interest,
     visual_transformation,
+    proteins_of_interest = None,
 ):
+    if proteins_of_interest is None:
+        proteins_of_interest = []
     return _build_box_hist_plot(
         df,
         result_df,
@@ -422,9 +428,11 @@ def by_min_per_sample_plot(
     graph_type,
     graph_type_quantities,
     group_by,
-    proteins_of_interest,
     visual_transformation,
+    proteins_of_interest = None,
 ):
+    if proteins_of_interest is None:
+        proteins_of_interest = []
     return _build_box_hist_plot(
         df,
         result_df,
@@ -443,9 +451,11 @@ def by_min_per_protein_plot(
     graph_type,
     graph_type_quantities,
     group_by,
-    proteins_of_interest,
     visual_transformation,
+    proteins_of_interest = None,
 ):
+    if proteins_of_interest is None:
+        proteins_of_interest = []
     return _build_box_hist_plot(
         df,
         result_df,
@@ -464,9 +474,11 @@ def by_min_per_dataset_plot(
     graph_type,
     graph_type_quantities,
     group_by,
-    proteins_of_interest,
     visual_transformation,
+    proteins_of_interest = None,
 ):
+    if proteins_of_interest is None:
+        proteins_of_interest = []
     return _build_box_hist_plot(
         df,
         result_df,

--- a/protzilla/data_preprocessing/imputation.py
+++ b/protzilla/data_preprocessing/imputation.py
@@ -360,7 +360,7 @@ def by_knn_plot(
     graph_type_quantities,
     group_by,
     visual_transformation,
-    proteins_of_interest = None,
+    proteins_of_interest=None,
 ):
     if proteins_of_interest is None:
         proteins_of_interest = []
@@ -383,7 +383,7 @@ def by_normal_distribution_sampling_plot(
     graph_type_quantities,
     group_by,
     visual_transformation,
-    proteins_of_interest = None,
+    proteins_of_interest=None,
 ):
     if proteins_of_interest is None:
         proteins_of_interest = []
@@ -406,7 +406,7 @@ def by_simple_imputer_plot(
     graph_type_quantities,
     group_by,
     visual_transformation,
-    proteins_of_interest = None,
+    proteins_of_interest=None,
 ):
     if proteins_of_interest is None:
         proteins_of_interest = []
@@ -429,7 +429,7 @@ def by_min_per_sample_plot(
     graph_type_quantities,
     group_by,
     visual_transformation,
-    proteins_of_interest = None,
+    proteins_of_interest=None,
 ):
     if proteins_of_interest is None:
         proteins_of_interest = []
@@ -452,7 +452,7 @@ def by_min_per_protein_plot(
     graph_type_quantities,
     group_by,
     visual_transformation,
-    proteins_of_interest = None,
+    proteins_of_interest=None,
 ):
     if proteins_of_interest is None:
         proteins_of_interest = []
@@ -475,7 +475,7 @@ def by_min_per_dataset_plot(
     graph_type_quantities,
     group_by,
     visual_transformation,
-    proteins_of_interest = None,
+    proteins_of_interest=None,
 ):
     if proteins_of_interest is None:
         proteins_of_interest = []
@@ -500,7 +500,7 @@ def _build_box_hist_plot(
     graph_type: str = "Boxplot",
     graph_type_quantities: str = "Pie chart",
     group_by: str = "None",
-    proteins_of_interest =None,
+    proteins_of_interest=None,
     visual_transformation: str = "linear",
 ) -> list[Figure]:
     """

--- a/protzilla/data_preprocessing/imputation.py
+++ b/protzilla/data_preprocessing/imputation.py
@@ -359,6 +359,7 @@ def by_knn_plot(
     graph_type,
     graph_type_quantities,
     group_by,
+    proteins_of_interest,
     visual_transformation,
 ):
     return _build_box_hist_plot(
@@ -367,6 +368,7 @@ def by_knn_plot(
         graph_type,
         graph_type_quantities,
         group_by,
+        proteins_of_interest,
         visual_transformation,
     )
 
@@ -378,6 +380,7 @@ def by_normal_distribution_sampling_plot(
     graph_type,
     graph_type_quantities,
     group_by,
+    proteins_of_interest,
     visual_transformation,
 ):
     return _build_box_hist_plot(
@@ -386,6 +389,7 @@ def by_normal_distribution_sampling_plot(
         graph_type,
         graph_type_quantities,
         group_by,
+        proteins_of_interest,
         visual_transformation,
     )
 
@@ -397,6 +401,7 @@ def by_simple_imputer_plot(
     graph_type,
     graph_type_quantities,
     group_by,
+    proteins_of_interest,
     visual_transformation,
 ):
     return _build_box_hist_plot(
@@ -405,6 +410,7 @@ def by_simple_imputer_plot(
         graph_type,
         graph_type_quantities,
         group_by,
+        proteins_of_interest,
         visual_transformation,
     )
 
@@ -416,6 +422,7 @@ def by_min_per_sample_plot(
     graph_type,
     graph_type_quantities,
     group_by,
+    proteins_of_interest,
     visual_transformation,
 ):
     return _build_box_hist_plot(
@@ -424,6 +431,7 @@ def by_min_per_sample_plot(
         graph_type,
         graph_type_quantities,
         group_by,
+        proteins_of_interest,
         visual_transformation,
     )
 
@@ -435,6 +443,7 @@ def by_min_per_protein_plot(
     graph_type,
     graph_type_quantities,
     group_by,
+    proteins_of_interest,
     visual_transformation,
 ):
     return _build_box_hist_plot(
@@ -443,6 +452,7 @@ def by_min_per_protein_plot(
         graph_type,
         graph_type_quantities,
         group_by,
+        proteins_of_interest,
         visual_transformation,
     )
 
@@ -454,6 +464,7 @@ def by_min_per_dataset_plot(
     graph_type,
     graph_type_quantities,
     group_by,
+    proteins_of_interest,
     visual_transformation,
 ):
     return _build_box_hist_plot(
@@ -462,6 +473,7 @@ def by_min_per_dataset_plot(
         graph_type,
         graph_type_quantities,
         group_by,
+        proteins_of_interest,
         visual_transformation,
     )
 
@@ -476,6 +488,7 @@ def _build_box_hist_plot(
     graph_type: str = "Boxplot",
     graph_type_quantities: str = "Pie chart",
     group_by: str = "None",
+    proteins_of_interest =None,
     visual_transformation: str = "linear",
 ) -> list[Figure]:
     """
@@ -511,6 +524,7 @@ def _build_box_hist_plot(
             name_b="Imputed Values",
             heading="Distribution of Protein Intensities",
             group_by=group_by,
+            proteins_of_interest=proteins_of_interest,
             visual_transformation=visual_transformation,
             y_title="Intensity",
         )

--- a/protzilla/data_preprocessing/normalisation.py
+++ b/protzilla/data_preprocessing/normalisation.py
@@ -4,7 +4,6 @@ import traceback
 import pandas as pd
 from sklearn.preprocessing import StandardScaler
 
-from protzilla.run_helper import get_parameters
 from protzilla.data_preprocessing.plots import create_box_plots, create_histograms
 from protzilla.utilities import default_intensity_column
 
@@ -231,31 +230,49 @@ def by_reference_protein(
     return scaled_df, dict(dropped_samples=dropped_samples)
 
 
-def by_z_score_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest = None):
+def by_z_score_plot(
+    df, result_df, current_out, graph_type, group_by, proteins_of_interest=None
+):
     if proteins_of_interest is None:
         proteins_of_interest = []
-    return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest)
+    return _build_box_hist_plot(
+        df, result_df, current_out, graph_type, group_by, proteins_of_interest
+    )
 
 
-def by_median_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest = None):
+def by_median_plot(
+    df, result_df, current_out, graph_type, group_by, proteins_of_interest=None
+):
     if proteins_of_interest is None:
         proteins_of_interest = []
-    return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest)
+    return _build_box_hist_plot(
+        df, result_df, current_out, graph_type, group_by, proteins_of_interest
+    )
 
 
-def by_totalsum_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest = None):
+def by_totalsum_plot(
+    df, result_df, current_out, graph_type, group_by, proteins_of_interest=None
+):
     if proteins_of_interest is None:
         proteins_of_interest = []
-    return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest = None)
+    return _build_box_hist_plot(
+        df, result_df, current_out, graph_type, group_by, proteins_of_interest
+    )
 
 
-def by_reference_protein_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest = None):
+def by_reference_protein_plot(
+    df, result_df, current_out, graph_type, group_by, proteins_of_interest=None
+):
     if proteins_of_interest is None:
         proteins_of_interest = []
-    return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest = None)
+    return _build_box_hist_plot(
+        df, result_df, current_out, graph_type, group_by, proteins_of_interest
+    )
 
 
-def _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest = None):
+def _build_box_hist_plot(
+    df, result_df, current_out, graph_type, group_by, proteins_of_interest=None
+):
     if graph_type == "Boxplot":
         fig = create_box_plots(
             dataframe_a=df,
@@ -267,7 +284,6 @@ def _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, prote
             y_title="Intensity",
             group_by=group_by,
             proteins_of_interest=proteins_of_interest,
-
         )
     if graph_type == "Histogram":
         fig = create_histograms(

--- a/protzilla/data_preprocessing/normalisation.py
+++ b/protzilla/data_preprocessing/normalisation.py
@@ -233,40 +233,55 @@ def by_reference_protein(
 def by_z_score_plot(
     df, result_df, current_out, graph_type, group_by, proteins_of_interest=None
 ):
-    if proteins_of_interest is None:
-        proteins_of_interest = []
     return _build_box_hist_plot(
-        df, result_df, current_out, graph_type, group_by, proteins_of_interest
+        df,
+        result_df,
+        current_out,
+        graph_type,
+        group_by,
+        [] if proteins_of_interest is None else proteins_of_interest,
     )
+
 
 
 def by_median_plot(
     df, result_df, current_out, graph_type, group_by, proteins_of_interest=None
 ):
-    if proteins_of_interest is None:
-        proteins_of_interest = []
     return _build_box_hist_plot(
-        df, result_df, current_out, graph_type, group_by, proteins_of_interest
+        df,
+        result_df,
+        current_out,
+        graph_type,
+        group_by,
+        [] if proteins_of_interest is None else proteins_of_interest,
     )
+
 
 
 def by_totalsum_plot(
     df, result_df, current_out, graph_type, group_by, proteins_of_interest=None
 ):
-    if proteins_of_interest is None:
-        proteins_of_interest = []
     return _build_box_hist_plot(
-        df, result_df, current_out, graph_type, group_by, proteins_of_interest
+        df,
+        result_df,
+        current_out,
+        graph_type,
+        group_by,
+        [] if proteins_of_interest is None else proteins_of_interest,
     )
+
 
 
 def by_reference_protein_plot(
     df, result_df, current_out, graph_type, group_by, proteins_of_interest=None
 ):
-    if proteins_of_interest is None:
-        proteins_of_interest = []
     return _build_box_hist_plot(
-        df, result_df, current_out, graph_type, group_by, proteins_of_interest
+        df,
+        result_df,
+        current_out,
+        graph_type,
+        group_by,
+        [] if proteins_of_interest is None else proteins_of_interest,
     )
 
 

--- a/protzilla/data_preprocessing/normalisation.py
+++ b/protzilla/data_preprocessing/normalisation.py
@@ -4,6 +4,7 @@ import traceback
 import pandas as pd
 from sklearn.preprocessing import StandardScaler
 
+from protzilla.run_helper import get_parameters
 from protzilla.data_preprocessing.plots import create_box_plots, create_histograms
 from protzilla.utilities import default_intensity_column
 
@@ -230,23 +231,23 @@ def by_reference_protein(
     return scaled_df, dict(dropped_samples=dropped_samples)
 
 
-def by_z_score_plot(df, result_df, current_out, graph_type, group_by):
-    return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by)
+def by_z_score_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest):
+    return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest)
 
 
-def by_median_plot(df, result_df, current_out, graph_type, group_by):
-    return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by)
+def by_median_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest):
+    return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest)
 
 
-def by_totalsum_plot(df, result_df, current_out, graph_type, group_by):
-    return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by)
+def by_totalsum_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest):
+    return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest)
 
 
-def by_reference_protein_plot(df, result_df, current_out, graph_type, group_by):
-    return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by)
+def by_reference_protein_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest):
+    return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest)
 
 
-def _build_box_hist_plot(df, result_df, current_out, graph_type, group_by):
+def _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest):
     if graph_type == "Boxplot":
         fig = create_box_plots(
             dataframe_a=df,
@@ -257,6 +258,8 @@ def _build_box_hist_plot(df, result_df, current_out, graph_type, group_by):
             x_title="",
             y_title="Intensity",
             group_by=group_by,
+            proteins_of_interest=proteins_of_interest,
+
         )
     if graph_type == "Histogram":
         fig = create_histograms(

--- a/protzilla/data_preprocessing/normalisation.py
+++ b/protzilla/data_preprocessing/normalisation.py
@@ -231,23 +231,31 @@ def by_reference_protein(
     return scaled_df, dict(dropped_samples=dropped_samples)
 
 
-def by_z_score_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest):
+def by_z_score_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest = None):
+    if proteins_of_interest is None:
+        proteins_of_interest = []
     return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest)
 
 
-def by_median_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest):
+def by_median_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest = None):
+    if proteins_of_interest is None:
+        proteins_of_interest = []
     return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest)
 
 
-def by_totalsum_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest):
-    return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest)
+def by_totalsum_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest = None):
+    if proteins_of_interest is None:
+        proteins_of_interest = []
+    return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest = None)
 
 
-def by_reference_protein_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest):
-    return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest)
+def by_reference_protein_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest = None):
+    if proteins_of_interest is None:
+        proteins_of_interest = []
+    return _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest = None)
 
 
-def _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest):
+def _build_box_hist_plot(df, result_df, current_out, graph_type, group_by, proteins_of_interest = None):
     if graph_type == "Boxplot":
         fig = create_box_plots(
             dataframe_a=df,

--- a/protzilla/data_preprocessing/plots.py
+++ b/protzilla/data_preprocessing/plots.py
@@ -149,7 +149,9 @@ def create_box_plots(
         proteins_of_interest = [proteins_of_interest]
 
     filtered_df = dataframe_a[dataframe_a["Protein ID"].isin(proteins_of_interest)]
-    filtered_result_df = dataframe_b[dataframe_b["Protein ID"].isin(proteins_of_interest)]
+    filtered_result_df = dataframe_b[
+        dataframe_b["Protein ID"].isin(proteins_of_interest)
+    ]
     intensity_name_a = default_intensity_column(filtered_df)
     intensity_name_b = default_intensity_column(filtered_result_df)
     if group_by in {"Sample", "Protein ID"}:

--- a/protzilla/data_preprocessing/plots.py
+++ b/protzilla/data_preprocessing/plots.py
@@ -110,7 +110,7 @@ def create_box_plots(
     y_title: str = "",
     x_title: str = "",
     group_by: str = "None",
-    proteins_of_interest =None,
+    proteins_of_interest=None,
     visual_transformation: str = "linear",
 ) -> Figure:
     """
@@ -143,6 +143,11 @@ def create_box_plots(
             f"""Group_by parameter  must be "None" or
                 "Sample" or "Protein ID" but is {group_by}"""
         )
+    if len(proteins_of_interest) == 0:
+        proteins_of_interest = dataframe_a["Protein ID"].iloc[:1]
+    elif not isinstance(proteins_of_interest, list):
+        proteins_of_interest = [proteins_of_interest]
+
     filtered_df = dataframe_a[dataframe_a["Protein ID"].isin(proteins_of_interest)]
     filtered_result_df = dataframe_b[dataframe_b["Protein ID"].isin(proteins_of_interest)]
     intensity_name_a = default_intensity_column(filtered_df)

--- a/protzilla/data_preprocessing/plots.py
+++ b/protzilla/data_preprocessing/plots.py
@@ -55,7 +55,7 @@ def create_bar_plot(
     names_of_sectors: "list[str]",
     values_of_sectors: "list[int]",
     heading: str = "",
-    colour: "list[str]" = PROTZILLA_DISCRETE_COLOR_OUTLIER_SEQUENCE,
+    color: "list[str]" = PROTZILLA_DISCRETE_COLOR_OUTLIER_SEQUENCE,
     y_title: str = "",
     x_title: str = "",
 ) -> Figure:
@@ -76,7 +76,7 @@ def create_bar_plot(
     fig = px.bar(
         x=names_of_sectors,
         y=values_of_sectors,
-        color=colour[: len(values_of_sectors)],
+        color=color[: len(values_of_sectors)],
         color_discrete_map="identity",
     )
 

--- a/protzilla/data_preprocessing/plots.py
+++ b/protzilla/data_preprocessing/plots.py
@@ -144,8 +144,8 @@ def create_box_plots(
                 "Sample" or "Protein ID" but is {group_by}"""
         )
     if len(proteins_of_interest) == 0:
-        proteins_of_interest = dataframe_a["Protein ID"].iloc[:1]
-    elif not isinstance(proteins_of_interest, list):
+        proteins_of_interest = dataframe_a["Protein ID"].iloc[:5]
+    elif isinstance(proteins_of_interest, str):
         proteins_of_interest = [proteins_of_interest]
 
     filtered_df = dataframe_a[dataframe_a["Protein ID"].isin(proteins_of_interest)]

--- a/protzilla/data_preprocessing/plots.py
+++ b/protzilla/data_preprocessing/plots.py
@@ -110,6 +110,7 @@ def create_box_plots(
     y_title: str = "",
     x_title: str = "",
     group_by: str = "None",
+    proteins_of_interest =None,
     visual_transformation: str = "linear",
 ) -> Figure:
     """
@@ -129,6 +130,7 @@ def create_box_plots(
     :param y_title: Optional y-axis title for graphs.
     :param x_title: Optional x-axis title for graphs.
     :param group_by: Optional argument to create a grouped boxplot\
+    :param proteins_of_interest: List of proteins to be included in the boxplot
     :param visual_transformation: Visual transformation of the y-axis data.
     graph. Arguments can be either "Sample" to group by sample or\
     "Protein ID" to group by protein. Leave "None" to get ungrouped\
@@ -141,19 +143,21 @@ def create_box_plots(
             f"""Group_by parameter  must be "None" or
                 "Sample" or "Protein ID" but is {group_by}"""
         )
-    intensity_name_a = default_intensity_column(dataframe_a)
-    intensity_name_b = default_intensity_column(dataframe_b)
+    filtered_df = dataframe_a[dataframe_a["Protein ID"].isin(proteins_of_interest)]
+    filtered_result_df = dataframe_b[dataframe_b["Protein ID"].isin(proteins_of_interest)]
+    intensity_name_a = default_intensity_column(filtered_df)
+    intensity_name_b = default_intensity_column(filtered_result_df)
     if group_by in {"Sample", "Protein ID"}:
         fig = make_subplots(rows=1, cols=2)
         trace0 = go.Box(
-            y=dataframe_a[intensity_name_a],
-            x=dataframe_a[group_by],
+            y=filtered_df[intensity_name_a],
+            x=filtered_df[group_by],
             marker_color=PROTZILLA_DISCRETE_COLOR_OUTLIER_SEQUENCE[0],
             name=name_a,
         )
         trace1 = go.Box(
-            y=dataframe_b[intensity_name_b],
-            x=dataframe_b[group_by],
+            y=filtered_result_df[intensity_name_b],
+            x=filtered_result_df[group_by],
             marker_color=PROTZILLA_DISCRETE_COLOR_OUTLIER_SEQUENCE[1],
             name=name_b,
         )
@@ -164,12 +168,12 @@ def create_box_plots(
     elif group_by == "None":
         fig = make_subplots(rows=1, cols=2)
         trace0 = go.Box(
-            y=dataframe_a[intensity_name_a],
+            y=filtered_df[intensity_name_a],
             marker_color=PROTZILLA_DISCRETE_COLOR_OUTLIER_SEQUENCE[0],
             name=name_a,
         )
         trace1 = go.Box(
-            y=dataframe_b[intensity_name_b],
+            y=filtered_result_df[intensity_name_b],
             marker_color=PROTZILLA_DISCRETE_COLOR_OUTLIER_SEQUENCE[1],
             name=name_b,
         )

--- a/protzilla/data_preprocessing/transformation.py
+++ b/protzilla/data_preprocessing/transformation.py
@@ -34,13 +34,32 @@ def by_log(intensity_df: pd.DataFrame, log_base="log10"):
     return transformed_df, dict()
 
 
-def by_log_plot(df, result_df, out, graph_type, group_by, proteins_of_interest = None,):
+def by_log_plot(
+    df,
+    result_df,
+    out,
+    graph_type,
+    group_by,
+    proteins_of_interest=None,
+):
     if proteins_of_interest is None:
         proteins_of_interest = []
-    return _build_box_hist_plot(df, result_df, graph_type, group_by, proteins_of_interest,)
+    return _build_box_hist_plot(
+        df,
+        result_df,
+        graph_type,
+        group_by,
+        proteins_of_interest,
+    )
 
 
-def _build_box_hist_plot(df, result_df, graph_type, group_by, proteins_of_interest,):
+def _build_box_hist_plot(
+    df,
+    result_df,
+    graph_type,
+    group_by,
+    proteins_of_interest,
+):
     if graph_type == "Boxplot":
         fig = create_box_plots(
             dataframe_a=df,

--- a/protzilla/data_preprocessing/transformation.py
+++ b/protzilla/data_preprocessing/transformation.py
@@ -34,11 +34,11 @@ def by_log(intensity_df: pd.DataFrame, log_base="log10"):
     return transformed_df, dict()
 
 
-def by_log_plot(df, result_df, out, graph_type, group_by):
-    return _build_box_hist_plot(df, result_df, graph_type, group_by)
+def by_log_plot(df, result_df, out, graph_type, group_by, proteins_of_interest,):
+    return _build_box_hist_plot(df, result_df, graph_type, group_by, proteins_of_interest,)
 
 
-def _build_box_hist_plot(df, result_df, graph_type, group_by):
+def _build_box_hist_plot(df, result_df, graph_type, group_by, proteins_of_interest,):
     if graph_type == "Boxplot":
         fig = create_box_plots(
             dataframe_a=df,
@@ -47,6 +47,7 @@ def _build_box_hist_plot(df, result_df, graph_type, group_by):
             name_b="After Transformation",
             heading="Distribution of Protein Intensities",
             group_by=group_by,
+            proteins_of_interest=proteins_of_interest,
             y_title="Intensity",
         )
     if graph_type == "Histogram":

--- a/protzilla/data_preprocessing/transformation.py
+++ b/protzilla/data_preprocessing/transformation.py
@@ -34,7 +34,9 @@ def by_log(intensity_df: pd.DataFrame, log_base="log10"):
     return transformed_df, dict()
 
 
-def by_log_plot(df, result_df, out, graph_type, group_by, proteins_of_interest,):
+def by_log_plot(df, result_df, out, graph_type, group_by, proteins_of_interest = None,):
+    if proteins_of_interest is None:
+        proteins_of_interest = []
     return _build_box_hist_plot(df, result_df, graph_type, group_by, proteins_of_interest,)
 
 

--- a/protzilla/data_preprocessing/transformation.py
+++ b/protzilla/data_preprocessing/transformation.py
@@ -42,14 +42,12 @@ def by_log_plot(
     group_by,
     proteins_of_interest=None,
 ):
-    if proteins_of_interest is None:
-        proteins_of_interest = []
     return _build_box_hist_plot(
         df,
         result_df,
         graph_type,
         group_by,
-        proteins_of_interest,
+        [] if proteins_of_interest is None else proteins_of_interest,
     )
 
 
@@ -58,7 +56,7 @@ def _build_box_hist_plot(
     result_df,
     graph_type,
     group_by,
-    proteins_of_interest,
+    proteins_of_interest=None,
 ):
     if graph_type == "Boxplot":
         fig = create_box_plots(

--- a/tests/protzilla/data_preprocessing/test_imputation.py
+++ b/tests/protzilla/data_preprocessing/test_imputation.py
@@ -161,6 +161,7 @@ def test_imputation_min_value_per_df(
         "Boxplot",
         "Bar chart",
         "Sample",
+        ["Protein1", "Protein2"],
         "linear",
     )
     if show_figures:
@@ -192,6 +193,7 @@ def test_imputation_min_value_per_sample(
         "Boxplot",
         "Bar chart",
         "Sample",
+        ["Protein1", "Protein2"],
         "linear",
     )
     if show_figures:
@@ -223,6 +225,7 @@ def test_imputation_min_value_per_protein(
         "Boxplot",
         "Bar chart",
         "Sample",
+        ["Protein1", "Protein2"],
         "linear",
     )
     if show_figures:
@@ -257,6 +260,7 @@ def test_imputation_mean_per_protein(
         "Boxplot",
         "Bar chart",
         "Sample",
+        ["Protein1", "Protein2"],
         "linear",
     )
     if show_figures:
@@ -289,6 +293,7 @@ def test_imputation_knn(show_figures, input_imputation_df, assertion_df_knn):
         "Boxplot",
         "Bar chart",
         "Sample",
+        ["Protein1", "Protein2"],
         "linear",
     )
     if show_figures:
@@ -321,6 +326,7 @@ def test_imputation_normal_distribution_sampling(show_figures, input_imputation_
         "Boxplot",
         "Bar chart",
         "Sample",
+        ["Protein1", "Protein2"],
         "linear",
     )
     if show_figures:

--- a/tests/protzilla/data_preprocessing/test_imputation.py
+++ b/tests/protzilla/data_preprocessing/test_imputation.py
@@ -161,8 +161,8 @@ def test_imputation_min_value_per_df(
         "Boxplot",
         "Bar chart",
         "Sample",
-        ["Protein1", "Protein2"],
         "linear",
+        [],
     )
     if show_figures:
         fig1.show()
@@ -193,8 +193,8 @@ def test_imputation_min_value_per_sample(
         "Boxplot",
         "Bar chart",
         "Sample",
-        ["Protein1", "Protein2"],
         "linear",
+        [],
     )
     if show_figures:
         fig1.show()
@@ -225,8 +225,8 @@ def test_imputation_min_value_per_protein(
         "Boxplot",
         "Bar chart",
         "Sample",
-        ["Protein1", "Protein2"],
         "linear",
+        [],
     )
     if show_figures:
         fig1.show()
@@ -260,8 +260,8 @@ def test_imputation_mean_per_protein(
         "Boxplot",
         "Bar chart",
         "Sample",
-        ["Protein1", "Protein2"],
         "linear",
+        [],
     )
     if show_figures:
         fig1.show()
@@ -293,8 +293,8 @@ def test_imputation_knn(show_figures, input_imputation_df, assertion_df_knn):
         "Boxplot",
         "Bar chart",
         "Sample",
-        ["Protein1", "Protein2"],
         "linear",
+        [],
     )
     if show_figures:
         fig1.show()
@@ -326,8 +326,8 @@ def test_imputation_normal_distribution_sampling(show_figures, input_imputation_
         "Boxplot",
         "Bar chart",
         "Sample",
-        ["Protein1", "Protein2"],
         "linear",
+        [],
     )
     if show_figures:
         fig1.show()

--- a/tests/protzilla/data_preprocessing/test_normalisation.py
+++ b/tests/protzilla/data_preprocessing/test_normalisation.py
@@ -310,7 +310,7 @@ def test_normalisation_by_z_score(
         dropouts,
         "Boxplot",
         "Sample",
-        ["Protein1", "Protein2"],
+        [],
     )[0]
     if show_figures:
         fig.show()
@@ -333,7 +333,7 @@ def test_normalisation_by_median(
         dropouts,
         "Boxplot",
         "Sample",
-        ["Protein1", "Protein2"],
+        [],
     )[0]
     if show_figures:
         fig.show()
@@ -364,7 +364,7 @@ def test_totalsum_normalisation(
         dropouts,
         "Boxplot",
         "Sample",
-        ["Protein1", "Protein2"],
+        [],
     )[0]
     if show_figures:
         fig.show()
@@ -395,7 +395,7 @@ def test_ref_protein_normalisation(
         dropouts,
         "Boxplot",
         "Sample",
-        ["Protein1", "Protein2"],
+        [],
     )[0]
     if show_figures:
         fig.show()

--- a/tests/protzilla/data_preprocessing/test_normalisation.py
+++ b/tests/protzilla/data_preprocessing/test_normalisation.py
@@ -304,7 +304,7 @@ def test_normalisation_by_z_score(
 ):
     result_df, dropouts = by_z_score(normalisation_df)
 
-    fig = by_z_score_plot(normalisation_df, result_df, dropouts, "Boxplot", "Sample")[0]
+    fig = by_z_score_plot(normalisation_df, result_df, dropouts, "Boxplot", "Sample", ["Protein1", "Protein2"],)[0]
     if show_figures:
         fig.show()
 
@@ -320,7 +320,7 @@ def test_normalisation_by_median(
 ):
     result_df, dropouts = by_median(normalisation_df)
 
-    fig = by_median_plot(normalisation_df, result_df, dropouts, "Boxplot", "Sample")[0]
+    fig = by_median_plot(normalisation_df, result_df, dropouts, "Boxplot", "Sample", ["Protein1", "Protein2"],)[0]
     if show_figures:
         fig.show()
 
@@ -344,7 +344,7 @@ def test_totalsum_normalisation(
 ):
     result_df, dropouts = by_totalsum(normalisation_df)
 
-    fig = by_totalsum_plot(normalisation_df, result_df, dropouts, "Boxplot", "Sample")[
+    fig = by_totalsum_plot(normalisation_df, result_df, dropouts, "Boxplot", "Sample", ["Protein1", "Protein2"],)[
         0
     ]
     if show_figures:
@@ -371,8 +371,7 @@ def test_ref_protein_normalisation(
     )
 
     fig = by_reference_protein_plot(
-        normalisation_by_ref_protein_df, result_df, dropouts, "Boxplot", "Sample"
-    )[0]
+        normalisation_by_ref_protein_df, result_df, dropouts, "Boxplot", "Sample", ["Protein1", "Protein2"])[0]
     if show_figures:
         fig.show()
 

--- a/tests/protzilla/data_preprocessing/test_normalisation.py
+++ b/tests/protzilla/data_preprocessing/test_normalisation.py
@@ -304,7 +304,14 @@ def test_normalisation_by_z_score(
 ):
     result_df, dropouts = by_z_score(normalisation_df)
 
-    fig = by_z_score_plot(normalisation_df, result_df, dropouts, "Boxplot", "Sample", ["Protein1", "Protein2"],)[0]
+    fig = by_z_score_plot(
+        normalisation_df,
+        result_df,
+        dropouts,
+        "Boxplot",
+        "Sample",
+        ["Protein1", "Protein2"],
+    )[0]
     if show_figures:
         fig.show()
 
@@ -320,7 +327,14 @@ def test_normalisation_by_median(
 ):
     result_df, dropouts = by_median(normalisation_df)
 
-    fig = by_median_plot(normalisation_df, result_df, dropouts, "Boxplot", "Sample", ["Protein1", "Protein2"],)[0]
+    fig = by_median_plot(
+        normalisation_df,
+        result_df,
+        dropouts,
+        "Boxplot",
+        "Sample",
+        ["Protein1", "Protein2"],
+    )[0]
     if show_figures:
         fig.show()
 
@@ -344,9 +358,14 @@ def test_totalsum_normalisation(
 ):
     result_df, dropouts = by_totalsum(normalisation_df)
 
-    fig = by_totalsum_plot(normalisation_df, result_df, dropouts, "Boxplot", "Sample", ["Protein1", "Protein2"],)[
-        0
-    ]
+    fig = by_totalsum_plot(
+        normalisation_df,
+        result_df,
+        dropouts,
+        "Boxplot",
+        "Sample",
+        ["Protein1", "Protein2"],
+    )[0]
     if show_figures:
         fig.show()
 
@@ -371,7 +390,13 @@ def test_ref_protein_normalisation(
     )
 
     fig = by_reference_protein_plot(
-        normalisation_by_ref_protein_df, result_df, dropouts, "Boxplot", "Sample", ["Protein1", "Protein2"])[0]
+        normalisation_by_ref_protein_df,
+        result_df,
+        dropouts,
+        "Boxplot",
+        "Sample",
+        ["Protein1", "Protein2"],
+    )[0]
     if show_figures:
         fig.show()
 

--- a/tests/protzilla/data_preprocessing/test_plots_data_preprocessing.py
+++ b/tests/protzilla/data_preprocessing/test_plots_data_preprocessing.py
@@ -51,6 +51,7 @@ def test_create_box_plots(
         name_b="After Transformation",
         heading="Distribution of Protein Intensities",
         group_by="None",
+        proteins_of_interest= ["Protein1", "Protein2"],
     )
     if show_figures:
         fig.show()
@@ -119,7 +120,9 @@ def test_build_box_hist_plot(
         "Boxplot",
         "Bar chart",
         "Sample",
+        ["Protein1", "Protein2"],
         "linear",
+
     )
     fig3, fig4 = imputation._build_box_hist_plot(
         input_imputation_df,

--- a/tests/protzilla/data_preprocessing/test_plots_data_preprocessing.py
+++ b/tests/protzilla/data_preprocessing/test_plots_data_preprocessing.py
@@ -51,7 +51,7 @@ def test_create_box_plots(
         name_b="After Transformation",
         heading="Distribution of Protein Intensities",
         group_by="None",
-        proteins_of_interest=["Protein1", "Protein2"],
+        proteins_of_interest=[],
     )
     if show_figures:
         fig.show()
@@ -64,7 +64,6 @@ def test_create_box_plots(
             group_by="wrong_group_by",
         )
     return
-
 
 @pytest.mark.order(1)
 @pytest.mark.dependency()
@@ -120,7 +119,7 @@ def test_build_box_hist_plot(
         "Boxplot",
         "Bar chart",
         "Sample",
-        ["Protein1", "Protein2"],
+        [],
         "linear",
     )
     fig3, fig4 = imputation._build_box_hist_plot(
@@ -129,6 +128,7 @@ def test_build_box_hist_plot(
         "Histogram",
         "Pie chart",
         "Protein ID",
+        [],
         "linear",
     )
 

--- a/tests/protzilla/data_preprocessing/test_plots_data_preprocessing.py
+++ b/tests/protzilla/data_preprocessing/test_plots_data_preprocessing.py
@@ -51,7 +51,7 @@ def test_create_box_plots(
         name_b="After Transformation",
         heading="Distribution of Protein Intensities",
         group_by="None",
-        proteins_of_interest= ["Protein1", "Protein2"],
+        proteins_of_interest=["Protein1", "Protein2"],
     )
     if show_figures:
         fig.show()
@@ -122,7 +122,6 @@ def test_build_box_hist_plot(
         "Sample",
         ["Protein1", "Protein2"],
         "linear",
-
     )
     fig3, fig4 = imputation._build_box_hist_plot(
         input_imputation_df,

--- a/tests/protzilla/data_preprocessing/test_transformation.py
+++ b/tests/protzilla/data_preprocessing/test_transformation.py
@@ -114,7 +114,14 @@ def test_log2_transformation(
 ):
     result_df = by_log(log2_transformation_df, log_base="log2")[0]
 
-    fig = by_log_plot(log2_transformation_df, result_df, {}, "Boxplot", "Protein ID", ["Protein1", "Protein2"],)[0]
+    fig = by_log_plot(
+        log2_transformation_df,
+        result_df,
+        {},
+        "Boxplot",
+        "Protein ID",
+        ["Protein1", "Protein2"],
+    )[0]
     if show_figures:
         fig.show()
 

--- a/tests/protzilla/data_preprocessing/test_transformation.py
+++ b/tests/protzilla/data_preprocessing/test_transformation.py
@@ -114,7 +114,7 @@ def test_log2_transformation(
 ):
     result_df = by_log(log2_transformation_df, log_base="log2")[0]
 
-    fig = by_log_plot(log2_transformation_df, result_df, {}, "Boxplot", "Protein ID")[0]
+    fig = by_log_plot(log2_transformation_df, result_df, {}, "Boxplot", "Protein ID", ["Protein1", "Protein2"],)[0]
     if show_figures:
         fig.show()
 
@@ -135,6 +135,7 @@ def test_log10_transformation(
         {},
         "Boxplot",
         "Protein ID",
+        proteins_of_interest=["Protein1", "Protein2"],
     )[0]
     if show_figures:
         fig.show()

--- a/tests/protzilla/data_preprocessing/test_transformation.py
+++ b/tests/protzilla/data_preprocessing/test_transformation.py
@@ -120,7 +120,7 @@ def test_log2_transformation(
         {},
         "Boxplot",
         "Protein ID",
-        ["Protein1", "Protein2"],
+        None,
     )[0]
     if show_figures:
         fig.show()
@@ -142,7 +142,7 @@ def test_log10_transformation(
         {},
         "Boxplot",
         "Protein ID",
-        proteins_of_interest=["Protein1", "Protein2"],
+        None,
     )[0]
     if show_figures:
         fig.show()

--- a/tests/protzilla/test_run.py
+++ b/tests/protzilla/test_run.py
@@ -321,7 +321,7 @@ def test_export_plot(tests_folder_name):
             graph_type="Boxplot",
             graph_type_quantities="Bar chart",
             group_by="Sample",
-            proteins_of_interest=["Protein1", "Protein2"],
+            proteins_of_interest=None,
             visual_transformation="linear",
         ),
     )

--- a/tests/protzilla/test_run.py
+++ b/tests/protzilla/test_run.py
@@ -321,6 +321,7 @@ def test_export_plot(tests_folder_name):
             graph_type="Boxplot",
             graph_type_quantities="Bar chart",
             group_by="Sample",
+            proteins_of_interest=["Protein1", "Protein2"],
             visual_transformation="linear",
         ),
     )

--- a/ui/runs/fields.py
+++ b/ui/runs/fields.py
@@ -175,7 +175,10 @@ def make_plot_fields(run: Run, section: str, step: str, method: str) -> str:
     plot_fields = []
     for plot in plots:
         for key, param_dict in plot.items():
-            if method in run.current_plot_parameters and key in run.current_plot_parameters[method]:
+            if (
+                method in run.current_plot_parameters
+                and key in run.current_plot_parameters[method]
+            ):
                 param_dict["default"] = run.current_plot_parameters[method][key]
             insert_special_params(param_dict, run)
             plot_fields.append(

--- a/ui/runs/fields.py
+++ b/ui/runs/fields.py
@@ -175,7 +175,7 @@ def make_plot_fields(run: Run, section: str, step: str, method: str) -> str:
     plot_fields = []
     for plot in plots:
         for key, param_dict in plot.items():
-            if method in run.current_plot_parameters:
+            if method in run.current_plot_parameters and key in run.current_plot_parameters[method]:
                 param_dict["default"] = run.current_plot_parameters[method][key]
             insert_special_params(param_dict, run)
             plot_fields.append(

--- a/ui/runs/fields.py
+++ b/ui/runs/fields.py
@@ -11,7 +11,7 @@ from main.settings import BASE_DIR
 
 sys.path.append(f"{BASE_DIR}/..")
 from protzilla.run import Run
-from protzilla.run_helper import get_parameters
+from protzilla.run_helper import get_parameters, insert_special_params
 from protzilla.utilities import name_to_title
 from protzilla.workflow_helper import (
     get_workflow_default_param_value,
@@ -177,6 +177,7 @@ def make_plot_fields(run: Run, section: str, step: str, method: str) -> str:
         for key, param_dict in plot.items():
             if method in run.current_plot_parameters:
                 param_dict["default"] = run.current_plot_parameters[method][key]
+            insert_special_params(param_dict, run)
             plot_fields.append(
                 make_parameter_input(key, param_dict, plot, disabled=False)
             )


### PR DESCRIPTION
## Description
fixes #330 
Added an option for the user to select a group of proteins, which can be used to plot a box plot

## Changes

1. workflow_meta: Added a Category for all the methods, where a box plot can be plotted
2. imputation, normalisation, transformation, plots: added a parameter for proteins_of_interest
3. Fields: it calls the function special_params from runs_helper to update the protein ID in the dynamic view
4. Also updated the test to the new structure


## Testing
1. Go through the preprocessing section and try plotting box plot in imputation, normalisation and transformation methods

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The code has been formatted with `black`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
