### PR TITLE
503 bug protquantplot volcano plot scatter plot is being saved in yaml

### DIFF
--- a/protzilla/methods/data_analysis.py
+++ b/protzilla/methods/data_analysis.py
@@ -32,7 +32,7 @@ class PlotStep(DataAnalysisStep):
 
     def handle_outputs(self, outputs: dict):
         super().handle_outputs(outputs)
-        plots = outputs.pop("plots", [])
+        plots = self.output.output.pop("plots", [])
         self.plots = Plots(plots)
 
 


### PR DESCRIPTION
## Description
fixes #503 
Literally one line change

## Testing
Go through standard workflow, and take a loonk at the run.yaml. Now the "outputs" dict in the yaml for the mentioned plotting steps should be empty

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The code has been formatted with `black`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
