### PR TITLE
Click-navigation to future steps

### DIFF
--- a/protzilla/steps.py
+++ b/protzilla/steps.py
@@ -260,6 +260,10 @@ class Messages:
     def clear(self):
         self.messages = []
 
+    @property
+    def empty(self) -> bool:
+        return len(self.messages) == 0
+
 
 class Plots:
     def __init__(self, plots: list | None = None):

--- a/protzilla/steps.py
+++ b/protzilla/steps.py
@@ -621,9 +621,17 @@ class StepManager:
 
         step = self.all_steps_in_section(section)[step_index]
         new_step_index = self.all_steps.index(step)
+
+        if new_step_index == self.current_step_index:
+            return
+        assert new_step_index < len(self.all_steps)
+
         if new_step_index < self.current_step_index:
             self.current_step_index = new_step_index
-        elif new_step_index < len(self.all_steps) and not step.output.is_empty:
+        elif (
+            not step.output.is_empty
+            or not self.all_steps[new_step_index - 1].output.is_empty
+        ):
             self.current_step_index = new_step_index
         else:
             raise ValueError(

--- a/protzilla/steps.py
+++ b/protzilla/steps.py
@@ -623,8 +623,12 @@ class StepManager:
         new_step_index = self.all_steps.index(step)
         if new_step_index < self.current_step_index:
             self.current_step_index = new_step_index
+        elif new_step_index < len(self.all_steps) and not step.output.is_empty:
+            self.current_step_index = new_step_index
         else:
-            raise ValueError("Cannot go to a step that is after the current step")
+            raise ValueError(
+                f"Cannot go to a step that has no output yet: {step.display_name}. Please calculate the steps beforehand first."
+            )
 
     def name_current_step_instance(self, new_instance_identifier: str) -> None:
         """

--- a/tests/protzilla/test_run.py
+++ b/tests/protzilla/test_run.py
@@ -1,5 +1,3 @@
-import logging
-
 from protzilla.methods.data_preprocessing import ImputationByMinPerProtein
 from protzilla.methods.importing import MaxQuantImport
 
@@ -91,12 +89,7 @@ class TestRun:
         step = ImputationByMinPerProtein()
         run_imported.step_add(step)
         run_imported.step_goto(0, "data_preprocessing")
-        assert any(
-            message["level"] == logging.ERROR and "ValueError" in message["msg"]
-            for message in run_imported.current_messages
-        ), "No error messages found in run.current_messages"
-        assert run_imported.current_step != step
-        run_imported.step_next()
+        assert run_imported.current_messages.empty
         assert run_imported.current_step == step
         run_imported.step_goto(0, "importing")
         assert run_imported.current_step == run_imported.steps.all_steps[0]


### PR DESCRIPTION
## Description
fixes #511 
## Changes
Just add a check when trying to go forward to see if that step has output. Because we automatically delete all the outputs of future steps on calculation, we should never have the issue that a previous step does not have output after going to a future step with output.


## Testing
Do a run, calculate some steps, go back and then go forwards again.

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The code has been formatted with `black`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
