### PR TITLE
fix key error after reload

### DIFF
--- a/ui/runs/views.py
+++ b/ui/runs/views.py
@@ -18,8 +18,8 @@ from django.http import (
 from django.shortcuts import render
 from django.urls import reverse
 
-from protzilla.run_helper import log_messages
 from protzilla.run import Run, get_available_run_names
+from protzilla.run_helper import log_messages
 from protzilla.stepfactory import StepFactory
 from protzilla.steps import Step
 from protzilla.utilities.utilities import (
@@ -242,6 +242,8 @@ def next_(request, run_name):
     :return: the rendered detail page of the run with the next step/method
     :rtype: HttpResponse
     """
+    if run_name not in active_runs:
+        active_runs[run_name] = Run(run_name)
     run = active_runs[run_name]
     name = request.POST.get("name", None)
     if name:
@@ -263,6 +265,8 @@ def back(request, run_name):
     :return: the rendered detail page of the run with the previous step/method
     :rtype: HttpResponse
     """
+    if run_name not in active_runs:
+        active_runs[run_name] = Run(run_name)
     run = active_runs[run_name]
     run.step_previous()
     return HttpResponseRedirect(reverse("runs:detail", args=(run_name,)))
@@ -283,6 +287,8 @@ def plot(request, run_name):
     :return: the rendered detail page of the run, now with the plot
     :rtype: HttpResponse
     """
+    if run_name not in active_runs:
+        active_runs[run_name] = Run(run_name)
     run = active_runs[run_name]
     parameters = parameters_from_post(request.POST)
 
@@ -353,6 +359,8 @@ def add(request: HttpRequest, run_name: str):
     :return: the rendered detail page of the run, new method visible in sidebar
     :rtype: HttpResponse
     """
+    if run_name not in active_runs:
+        active_runs[run_name] = Run(run_name)
     run = active_runs[run_name]
     method = dict(request.POST)["method"][0]
 
@@ -373,6 +381,8 @@ def export_workflow(request: HttpRequest, run_name: str):
     :return: the rendered detail page of the run
     :rtype: HttpResponse
     """
+    if run_name not in active_runs:
+        active_runs[run_name] = Run(run_name)
     run = active_runs[run_name]
     requested_workflow_name = request.POST["name"]
     run._workflow_export(requested_workflow_name)
@@ -392,7 +402,8 @@ def download_plots(request: HttpRequest, run_name: str):
     :return: a FileResponse with the plots
     :rtype: FileResponse
     """
-
+    if run_name not in active_runs:
+        active_runs[run_name] = Run(run_name)
     run = active_runs[run_name]
     format_ = request.GET["format"]
     index = run.steps.current_step_index
@@ -428,6 +439,8 @@ def delete_step(request: HttpRequest, run_name: str):
     :return: the rendered detail page of the run, deleted method no longer visible in sidebar
     :rtype: HttpResponse
     """
+    if run_name not in active_runs:
+        active_runs[run_name] = Run(run_name)
     run = active_runs[run_name]
 
     post = dict(request.POST)
@@ -447,6 +460,8 @@ def navigate(request, run_name: str):
 
     :return: the rendered detail page of the run with the specified step/method
     """
+    if run_name not in active_runs:
+        active_runs[run_name] = Run(run_name)
     run = active_runs[run_name]
 
     post = dict(request.POST)
@@ -460,6 +475,8 @@ def navigate(request, run_name: str):
 
 
 def tables_content(request, run_name, index, key):
+    if run_name not in active_runs:
+        active_runs[run_name] = Run(run_name)
     run = active_runs[run_name]
     # TODO this will change with df_mode implementation
     if index < len(run.steps.previous_steps):
@@ -585,6 +602,8 @@ def fill_form(request: HttpRequest, run_name: str):
     :return: the filled form
     :rtype: HttpResponse
     """
+    if run_name not in active_runs:
+        active_runs[run_name] = Run(run_name)
     run = active_runs[run_name]
     method_form = get_filled_form_by_request(request, run)
     form_html = ""
@@ -607,6 +626,8 @@ def add_name(request, run_name):
     :return: the rendered detail page of the run
     :rtype: HttpResponse
     """
+    if run_name not in active_runs:
+        active_runs[run_name] = Run(run_name)
     run = active_runs[run_name]
     run.name_step(int(request.POST["index"]), request.POST["name"])
     return HttpResponseRedirect(reverse("runs:detail", args=(run_name,)))


### PR DESCRIPTION
## Description

When the application was reloaded (and therefore the active_runs dict is cleared) we failed on most operations (back, add, plot etc.). We can easily fix that by adding the current run to the active_runs when necessary in every operation. 

This change won't be affecting users a lot but we get a nicer development experience.


## Changes
In the `runs/views.py` for most operation we added handling for empty active_runs.


## Testing
Go through a worklow in PROTzilla, trigger an application reload, check that operations are working without failing.

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The code has been formatted with `black`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
