### PR TITLE
Adds dedeplucation to metadata loading

### DIFF
--- a/protzilla/importing/metadata_import.py
+++ b/protzilla/importing/metadata_import.py
@@ -40,6 +40,9 @@ def file_importer(file_path: str) -> tuple[pd.DataFrame, str]:
                 "File format not supported. \
             Supported file formats are csv, xlsx, psv or tsv",
             )
+        # If duplicates are not remove this could negatively impact downstream analysis, e.g. produces wrong p-values
+        # in differential expression tests.
+        meta_df = meta_df.drop_duplicates()
         msg = "Metadata file successfully imported."
         return meta_df, msg
     except pd.errors.EmptyDataError:


### PR DESCRIPTION
## Description

Prevents bugs related to malformed metadata dataframes. If metadata contains duplicate entries, this will lead to duplicate intensity entries in differential expression testing, which in turn leads to wrong p-values.

It's debatable if the import step is the only place where this de-duplication takes place or if this should also be done in the respective testing steps. 

## Changes

Adds `.drop_duplicates()` in metadata loading

## Testing

In this [zip file](https://github.com/user-attachments/files/16815912/data.zip), you can find the used workflow and the malformed metadata.   
I loaded the standard `proteinGroups.txt` file and ran all steps with default params.

Before the changes, the normal `meta.txt` file and `meta_dups.txt` should return different p-values, e.g. 1.709e-15 (normal) and 5.827e-49 (duplicated) for Tau (P10636).