### PR TITLE
Calculate spinner and hide next button

### DIFF
--- a/ui/runs/static/runs/runs.js
+++ b/ui/runs/static/runs/runs.js
@@ -32,4 +32,14 @@ $(document).ready(function () {
         let id = $(this).attr("id");
         $('#chosen-' + id).text(this.files[0].name);
     });
+
+
+    // calculate button spinner
+    $('.calculateSpinner').on('click', function() {        
+        // Change button content to show 'Calculating...' with a spinner
+        $(this).html(`
+            <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+            Calculating...
+        `);
+    });
 });

--- a/ui/runs/templates/runs/details.html
+++ b/ui/runs/templates/runs/details.html
@@ -277,8 +277,9 @@
                                         </div>
                                     </div>
                                     {% endif %}
-                                    <button class="btn btn-red"  {% if not results_exist or last_step %} disabled {% endif %}>Next
-                                    </button>
+                                    {% if not last_step %}
+                                        <button class="btn btn-red" {% if not results_exist %} disabled {% endif %} >Next</button>
+                                    {% endif %}
                                 </div>
                             </form>
                         </div>

--- a/ui/runs/templates/runs/details.html
+++ b/ui/runs/templates/runs/details.html
@@ -140,8 +140,10 @@
                                             </div>
                                         {% endfor %}
                                     </div>
-                                    <input type="submit" id="calculate_parameters_submit" value="Calculate"
+                                    <button type="submit" id="calculate_parameters_submit"
                                            class="btn btn-red calculateSpinner">
+                                           Calculate
+                                    </button>
                                 </form>
                             </div>
                             <div class="col">

--- a/ui/runs/templates/runs/details.html
+++ b/ui/runs/templates/runs/details.html
@@ -24,8 +24,8 @@
 {% endblock %}
 
 {% block content %}
-
-    <div class="wrapper">
+    
+<div class="wrapper">
         {# include sidebar #}
         <nav id="sidebar" class="border border-end-0 border-top-0 border-bottom-0">
             {{ sidebar }}
@@ -141,7 +141,7 @@
                                         {% endfor %}
                                     </div>
                                     <input type="submit" id="calculate_parameters_submit" value="Calculate"
-                                           class="btn btn-red">
+                                           class="btn btn-red calculateSpinner">
                                 </form>
                             </div>
                             <div class="col">
@@ -174,8 +174,10 @@
                                             {% endfor %}
                                         </div>
                                         <div class="form-group">
-                                            <input type="submit" value="Calculate" id="calculate_parameters_submit"
-                                                   class="btn btn-red mr-auto">
+                                            <button type="submit" id="calculate_parameters_submit"
+                                                   class="btn btn-red mr-auto calculateSpinner">
+                                                Calculate
+                                            </button>
                                             {% if section == "data_preprocessing" %}
                                                 <a href="{% url 'runs:plot' run_name %}" id="plot_parameters_submit" class="btn btn-grey {% if not show_plot_button %} disabled {% endif %}">Plot</a>
                                             {% endif %}


### PR DESCRIPTION
## Description
The calculate button shows a loading spinner while calculating. The next button at the last step is now hidden.

## Changes
ui/runs/static/runs/runs.js
ui/runs/templates/runs/details.html

## Testing
A walkthrough with steps of a sample workflow.

## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The code has been formatted with `black`
 
**Code review**
- [ ] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
