### PR TITLE
Saving collapse after reload

### DIFF
--- a/ui/runs/static/runs/runs.js
+++ b/ui/runs/static/runs/runs.js
@@ -21,6 +21,37 @@ $(document).ready(function () {
         }
     });
 
+    /*// control each step-adding section visibility
+    let addStepsState = JSON.parse(sessionStorage.getItem("addStepsState")) || {};
+    // hide add-step section per default
+    $('id^="add_steps_div_"]').each(function() {
+        let section = $(this);
+        let sectionId = section.id; 
+
+        // Get the collapse state for this section from the stored addStepsState
+        let isCollapsed = addStepsState[sectionId] === 'collapsed';
+
+        // Set the initial visibility based on the state
+        if (isCollapsed) {
+            section.removeClass('show');
+            section.find('.toggleChevronAddStep').removeClass('rotate-icon');
+        } else {
+            section.addClass('show');
+            section.find('.toggleChevronAddStep').addClass('rotate-icon');
+        }
+
+        // Attach click event to toggle button
+        section.find('.toggleChevronAddStep').on('click', function() {
+            $(this).toggleClass('rotate-icon');
+            let currentlyCollapsed = $(this).attr('aria-expanded') === 'false';
+
+            // Update the addStepsState object with the new state for this section
+            addStepsState[sectionId] = currentlyCollapsed ? 'collapsed' : 'expanded';
+
+            // Save the updated state object to sessionStorage
+            sessionStorage.setItem("addStepsState", JSON.stringify(addStepsState));
+        });
+    });*/
 
     // control sidebar visibility
     $('#sidebarCollapse').on('click', function () {
@@ -51,7 +82,7 @@ $(document).ready(function () {
         `);
     });
 
-    // save current state of accordion in localStorage
+    // save current state of accordion in sessionStorage
     function saveAccordionState() {
         const panels = [];
         $(".collapse").each(function () {
@@ -59,12 +90,12 @@ $(document).ready(function () {
                 panels.push(this.id);
             }
         });
-        localStorage.setItem("accordionState", JSON.stringify(panels));
+        sessionStorage.setItem("accordionState", JSON.stringify(panels));
     }
 
-    // load accordion state from localStorage
+    // load accordion state from sessionStorage
     function loadAccordionState() {
-        const panels = JSON.parse(localStorage.getItem("accordionState")) || [];
+        const panels = JSON.parse(sessionStorage.getItem("accordionState")) || [];
         panels.forEach(function (panelId) {
             const panel = $("#" + panelId);
             if (panel.length) {
@@ -73,9 +104,59 @@ $(document).ready(function () {
         });
     }
 
+    /*function loadAccordionState() {
+        const panels = JSON.parse(localStorage.getItem("accordionState")) || [];
+        $(".collapse").each(function () {
+            const panel = $(this);
+            const button = document.querySelector(`[data-bs-target="#${panel.attr("id")}"]`);
+            if (panel.length) {
+                panel.addClass("show"); 
+                if (panels.includes(panel.attr("id"))) {
+                    // Expand the panel
+                    if (button) {
+                        const icon = button.id === 'sidebar-accordion'
+                            ? button.querySelectorAll('svg')[1] // second svg to skip section icon
+                            : button.querySelector('svg');
+                        if (icon) icon.classList.add("rotate-icon");
+                    }
+                } else {
+                    //panel.removeClass("show"); // Collapse the panel
+                    if (button) {
+                        const icon = button.id === 'sidebar-accordion'
+                            ? button.querySelectorAll('svg')[1]
+                            : button.querySelector('svg');
+                        if (icon) icon.classList.remove("rotate-icon");
+                    }
+                }
+            }
+        });
+    }*/
+        
+
     loadAccordionState();
 
     // event listeners save collapse state on show/hide to local storage
     $(".collapse").on("shown.bs.collapse", saveAccordionState);
     $(".collapse").on("hidden.bs.collapse", saveAccordionState);
+
+    // event listeners for all add-steps buttons to handle drop-down arrow
+    document.querySelectorAll('#add-steps-button, #sidebar-accordion').forEach(button => {
+        const targetId = button.getAttribute('data-bs-target');
+        const targetElement = document.querySelector(targetId);
+
+        // Listen for collapse events
+        targetElement.addEventListener('show.bs.collapse', () => {
+            const icon = button.id === 'sidebar-accordion' 
+                ? button.querySelectorAll('svg')[1] // second svg to skip section icon
+                : button.querySelector('svg');
+            icon.classList.add('rotate-icon');
+        });
+    
+        targetElement.addEventListener('hide.bs.collapse', () => {
+            const icon = button.id === 'sidebar-accordion' 
+                ? button.querySelectorAll('svg')[1] // second svg to skip section icon
+                : button.querySelector('svg');
+            icon.classList.remove('rotate-icon');
+        });
+    });
 });

--- a/ui/runs/static/runs/runs.js
+++ b/ui/runs/static/runs/runs.js
@@ -21,38 +21,6 @@ $(document).ready(function () {
         }
     });
 
-    /*// control each step-adding section visibility
-    let addStepsState = JSON.parse(sessionStorage.getItem("addStepsState")) || {};
-    // hide add-step section per default
-    $('id^="add_steps_div_"]').each(function() {
-        let section = $(this);
-        let sectionId = section.id; 
-
-        // Get the collapse state for this section from the stored addStepsState
-        let isCollapsed = addStepsState[sectionId] === 'collapsed';
-
-        // Set the initial visibility based on the state
-        if (isCollapsed) {
-            section.removeClass('show');
-            section.find('.toggleChevronAddStep').removeClass('rotate-icon');
-        } else {
-            section.addClass('show');
-            section.find('.toggleChevronAddStep').addClass('rotate-icon');
-        }
-
-        // Attach click event to toggle button
-        section.find('.toggleChevronAddStep').on('click', function() {
-            $(this).toggleClass('rotate-icon');
-            let currentlyCollapsed = $(this).attr('aria-expanded') === 'false';
-
-            // Update the addStepsState object with the new state for this section
-            addStepsState[sectionId] = currentlyCollapsed ? 'collapsed' : 'expanded';
-
-            // Save the updated state object to sessionStorage
-            sessionStorage.setItem("addStepsState", JSON.stringify(addStepsState));
-        });
-    });*/
-
     // control sidebar visibility
     $('#sidebarCollapse').on('click', function () {
         $('#sidebar').toggleClass('active');
@@ -104,59 +72,30 @@ $(document).ready(function () {
         });
     }
 
-    /*function loadAccordionState() {
-        const panels = JSON.parse(localStorage.getItem("accordionState")) || [];
+    function updateAccordionIcons() {
         $(".collapse").each(function () {
             const panel = $(this);
             const button = document.querySelector(`[data-bs-target="#${panel.attr("id")}"]`);
-            if (panel.length) {
-                panel.addClass("show"); 
-                if (panels.includes(panel.attr("id"))) {
-                    // Expand the panel
-                    if (button) {
-                        const icon = button.id === 'sidebar-accordion'
-                            ? button.querySelectorAll('svg')[1] // second svg to skip section icon
-                            : button.querySelector('svg');
-                        if (icon) icon.classList.add("rotate-icon");
-                    }
+            if (button) {
+                const icon = button.id === 'sidebar-accordion'
+                    ? button.querySelectorAll('svg')[1] // second svg to skip section icon
+                    : button.querySelector('svg');
+                if (panel.hasClass("show")) {
+                    if (icon) icon.classList.add("rotate-icon");
                 } else {
-                    //panel.removeClass("show"); // Collapse the panel
-                    if (button) {
-                        const icon = button.id === 'sidebar-accordion'
-                            ? button.querySelectorAll('svg')[1]
-                            : button.querySelector('svg');
-                        if (icon) icon.classList.remove("rotate-icon");
-                    }
+                    if (icon) icon.classList.remove("rotate-icon");
                 }
             }
         });
-    }*/
+    }
         
-
     loadAccordionState();
+    updateAccordionIcons();
 
     // event listeners save collapse state on show/hide to local storage
-    $(".collapse").on("shown.bs.collapse", saveAccordionState);
     $(".collapse").on("hidden.bs.collapse", saveAccordionState);
-
-    // event listeners for all add-steps buttons to handle drop-down arrow
-    document.querySelectorAll('#add-steps-button, #sidebar-accordion').forEach(button => {
-        const targetId = button.getAttribute('data-bs-target');
-        const targetElement = document.querySelector(targetId);
-
-        // Listen for collapse events
-        targetElement.addEventListener('show.bs.collapse', () => {
-            const icon = button.id === 'sidebar-accordion' 
-                ? button.querySelectorAll('svg')[1] // second svg to skip section icon
-                : button.querySelector('svg');
-            icon.classList.add('rotate-icon');
-        });
-    
-        targetElement.addEventListener('hide.bs.collapse', () => {
-            const icon = button.id === 'sidebar-accordion' 
-                ? button.querySelectorAll('svg')[1] // second svg to skip section icon
-                : button.querySelector('svg');
-            icon.classList.remove('rotate-icon');
-        });
+    $(".collapse").on("shown.bs.collapse hidden.bs.collapse", function () {
+        saveAccordionState(); // Save the current state to sessionStorage
+        updateAccordionIcons(); // Update icons after state change
     });
 });

--- a/ui/runs/static/runs/runs.js
+++ b/ui/runs/static/runs/runs.js
@@ -51,7 +51,7 @@ $(document).ready(function () {
         `);
     });
 
-    // Function to save the current state of the accordion in localStorage
+    // save current state of accordion in localStorage
     function saveAccordionState() {
         const panels = [];
         $(".collapse").each(function () {
@@ -62,7 +62,7 @@ $(document).ready(function () {
         localStorage.setItem("accordionState", JSON.stringify(panels));
     }
 
-    // Function to load the accordion state from localStorage
+    // load accordion state from localStorage
     function loadAccordionState() {
         const panels = JSON.parse(localStorage.getItem("accordionState")) || [];
         panels.forEach(function (panelId) {
@@ -73,10 +73,9 @@ $(document).ready(function () {
         });
     }
 
-    // Load accordion state on page load
     loadAccordionState();
 
-    // Set up event listeners for accordion panels to save state on show/hide
+    // event listeners save collapse state on show/hide to local storage
     $(".collapse").on("shown.bs.collapse", saveAccordionState);
     $(".collapse").on("hidden.bs.collapse", saveAccordionState);
 });

--- a/ui/runs/static/runs/runs.js
+++ b/ui/runs/static/runs/runs.js
@@ -50,4 +50,33 @@ $(document).ready(function () {
             Calculating...
         `);
     });
+
+    // Function to save the current state of the accordion in localStorage
+    function saveAccordionState() {
+        const panels = [];
+        $(".collapse").each(function () {
+            if ($(this).hasClass("show")) {
+                panels.push(this.id);
+            }
+        });
+        localStorage.setItem("accordionState", JSON.stringify(panels));
+    }
+
+    // Function to load the accordion state from localStorage
+    function loadAccordionState() {
+        const panels = JSON.parse(localStorage.getItem("accordionState")) || [];
+        panels.forEach(function (panelId) {
+            const panel = $("#" + panelId);
+            if (panel.length) {
+                panel.addClass("show");
+            }
+        });
+    }
+
+    // Load accordion state on page load
+    loadAccordionState();
+
+    // Set up event listeners for accordion panels to save state on show/hide
+    $(".collapse").on("shown.bs.collapse", saveAccordionState);
+    $(".collapse").on("hidden.bs.collapse", saveAccordionState);
 });

--- a/ui/runs/templates/runs/sidebar.html
+++ b/ui/runs/templates/runs/sidebar.html
@@ -8,12 +8,14 @@
     <div id="accordion" class="">
         {% for section in workflow_steps %}
             <div class="border-top">
-                <div class="card-header d-flex btn p-3 align-items-center bg-white border-bottom" data-bs-toggle="collapse"
+                <div id="sidebar-accordion" class="card-header d-flex btn p-3 align-items-center bg-white border-bottom" data-bs-toggle="collapse" data-bs-target="#collapse_{{ section.id }}"
                      href="#collapse_{{ section.id }}">
                     
                     {# add section icon #}
                     {% if section.id == 'importing' %}
-                        <img src="{% static 'img/download-file-icon.svg' %}" alt="toggle sidebar" width="20" height="20" class="me-1">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="23" height="23" fill="#4A536A" class="bi bi-cloud-download-fill" viewBox="0 0 16 16">
+                            <path fill-rule="evenodd" d="M8 0a5.53 5.53 0 0 0-3.594 1.342c-.766.66-1.321 1.52-1.464 2.383C1.266 4.095 0 5.555 0 7.318 0 9.366 1.708 11 3.781 11H7.5V5.5a.5.5 0 0 1 1 0V11h4.188C14.502 11 16 9.57 16 7.773c0-1.636-1.242-2.969-2.834-3.194C12.923 1.999 10.69 0 8 0m-.354 15.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 14.293V11h-1v3.293l-2.146-2.147a.5.5 0 0 0-.708.708z"/>
+                        </svg>
                     {% elif section.id == 'data_preprocessing' %}
                         <svg xmlns="http://www.w3.org/2000/svg" width="23" height="23" fill="#4A536A" class="bi bi-gear-fill" viewBox="0 0 16 16">
                             <path d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z"/>
@@ -32,6 +34,9 @@
                     <div class="ms-3">
                         {{ section.name }}
                     </div>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-compact-down ms-auto" viewBox="0 0 16 16">
+                        <path fill-rule="evenodd" d="M1.553 6.776a.5.5 0 0 1 .67-.223L8 9.44l5.776-2.888a.5.5 0 1 1 .448.894l-6 3a.5.5 0 0 1-.448 0l-6-3a.5.5 0 0 1-.223-.67"/>
+                      </svg>
                 </div>
                 <div id="collapse_{{ section.id }}"
                      class="collapse{% if section.selected %} show {% endif %}">

--- a/ui/runs/templates/runs/sidebar.html
+++ b/ui/runs/templates/runs/sidebar.html
@@ -36,7 +36,7 @@
                 <!-- <div id="collapse_{{ section.id }}"
                      class="collapse{% if section.selected %} show {% endif %}"> -->
                 <div id="collapse_{{ section.id }}"
-                     class="collapse">
+                     class="collapse {% if section.selected %} show {% endif %}">
                     <div class="card-body my-2">
                         {% include "runs/sidebar_section.html" with section=section run_name=run_name %}
                     </div>

--- a/ui/runs/templates/runs/sidebar.html
+++ b/ui/runs/templates/runs/sidebar.html
@@ -33,8 +33,10 @@
                         {{ section.name }}
                     </div>
                 </div>
+                <!-- <div id="collapse_{{ section.id }}"
+                     class="collapse{% if section.selected %} show {% endif %}"> -->
                 <div id="collapse_{{ section.id }}"
-                     class="collapse{% if section.selected %} show {% endif %}">
+                     class="collapse">
                     <div class="card-body my-2">
                         {% include "runs/sidebar_section.html" with section=section run_name=run_name %}
                     </div>

--- a/ui/runs/templates/runs/sidebar.html
+++ b/ui/runs/templates/runs/sidebar.html
@@ -33,10 +33,8 @@
                         {{ section.name }}
                     </div>
                 </div>
-                <!-- <div id="collapse_{{ section.id }}"
-                     class="collapse{% if section.selected %} show {% endif %}"> -->
                 <div id="collapse_{{ section.id }}"
-                     class="collapse {% if section.selected %} show {% endif %}">
+                     class="collapse{% if section.selected %} show {% endif %}">
                     <div class="card-body my-2">
                         {% include "runs/sidebar_section.html" with section=section run_name=run_name %}
                     </div>

--- a/ui/runs/templates/runs/sidebar_section.html
+++ b/ui/runs/templates/runs/sidebar_section.html
@@ -1,7 +1,5 @@
 {# params: run_name section{id, name, finished, selected, possible_steps{id, name, methods{id, name, description}}, steps{id, name, finished, selected, index, method_name}} #}
 
-<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
-
 {% block js %}
     <script>
         $(function () {
@@ -38,7 +36,7 @@
                 </form>
             {% endif %}
 
-        </div>  
+        </div>
     {% endfor %}
 </div>
 

--- a/ui/runs/templates/runs/sidebar_section.html
+++ b/ui/runs/templates/runs/sidebar_section.html
@@ -1,5 +1,7 @@
 {# params: run_name section{id, name, finished, selected, possible_steps{id, name, methods{id, name, description}}, steps{id, name, finished, selected, index, method_name}} #}
 
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
+
 {% block js %}
     <script>
         $(function () {
@@ -13,7 +15,7 @@
 <div>
     {% for step in section.steps %}
         <div class="wrapper {% if step.selected %}selected{% endif %} {% if step.finished %}finished{% endif %} d-flex align-items-center">
-            <form action="{% url 'runs:navigate' run_name %}" method="post" class="ms-auto">
+            <form action="{% url 'runs:navigate' run_name %}" method="post">
                 {% csrf_token %}
                 <input type="hidden" name="section_name" value="{{ section.id }}">
                 <input type="hidden" name="index" value="{{ step.index }}">
@@ -24,16 +26,15 @@
 
             {% if not step.selected and not step.finished %}
                 {# button to remove step from workflow #}
-                <form action="{% url 'runs:delete_step' run_name %}" method="post">
+                <form action="{% url 'runs:delete_step' run_name %}" method="post" class="ms-auto">
                     {% csrf_token %}
                     <input type="hidden" name="index" value="{{ step.index }}">
                     <input type="hidden" name="section" value="{{ step.section }}">
-                    <button class="removeBtn btn d-flex justify-content-center align-items-end mt-1">                    
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="grey" class="bi bi-trash removeIcon">
-                            <path d="M5.5 5.5v7h1v-7h-1zm3 0v7h1v-7h-1z"/>
-                            <path d="M11 1.5H5l-.5.5H3.5A.5.5 0 0 0 3 2.5v1a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5H11.5l-.5-.5zm-7 1h6l.5.5h-7l.5-.5zm1.25 3v7A.75.75 0 0 0 7 13.75h2A.75.75 0 0 0 9.75 12v-7H5.25z"/>
-                        </svg>
-                    </button>
+                    <button class="removeBtn btn d-flex justify-content-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="grey" class="bi bi-trash3-fill" viewBox="0 0 16 16">
+                            <path d="M2.5 1a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1H3v9a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V4h.5a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H10a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1zm3 4a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 .5-.5M8 5a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7A.5.5 0 0 1 8 5m3 .5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 1 0"/>
+                          </svg>
+                    </button>                    
                 </form>
             {% endif %}
 

--- a/ui/runs/templates/runs/sidebar_section.html
+++ b/ui/runs/templates/runs/sidebar_section.html
@@ -13,7 +13,7 @@
 <div>
     {% for step in section.steps %}
         <div class="wrapper {% if step.selected %}selected{% endif %} {% if step.finished %}finished{% endif %} d-flex align-items-center">
-            <form action="{% url 'runs:navigate' run_name %}" method="post">
+            <form action="{% url 'runs:navigate' run_name %}" method="post" class="ms-auto">
                 {% csrf_token %}
                 <input type="hidden" name="section_name" value="{{ section.id }}">
                 <input type="hidden" name="index" value="{{ step.index }}">
@@ -28,14 +28,16 @@
                     {% csrf_token %}
                     <input type="hidden" name="index" value="{{ step.index }}">
                     <input type="hidden" name="section" value="{{ step.section }}">
-                    <button class="removeBtn btn d-flex justify-content-center align-items-end mt-1">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="grey" class="bi bi-x removeIcon">
-                        <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/>
-                    </svg></button>
+                    <button class="removeBtn btn d-flex justify-content-center align-items-end mt-1">                    
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="grey" class="bi bi-trash removeIcon">
+                            <path d="M5.5 5.5v7h1v-7h-1zm3 0v7h1v-7h-1z"/>
+                            <path d="M11 1.5H5l-.5.5H3.5A.5.5 0 0 0 3 2.5v1a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5H11.5l-.5-.5zm-7 1h6l.5.5h-7l.5-.5zm1.25 3v7A.75.75 0 0 0 7 13.75h2A.75.75 0 0 0 9.75 12v-7H5.25z"/>
+                        </svg>
+                    </button>
                 </form>
             {% endif %}
 
-        </div>
+        </div>  
     {% endfor %}
 </div>
 

--- a/ui/runs/templates/runs/sidebar_section.html
+++ b/ui/runs/templates/runs/sidebar_section.html
@@ -43,9 +43,12 @@
 {% if section.finished %}
     <p class="pb-2"><i class="text-muted">Go back to this section to add more steps</i></p>
 {% else %}
-    <button class="btn btn-blue full_width mt-2 mb-2" type="button" data-bs-toggle="collapse"
+    <button id="add-steps-button" class="btn btn-blue full_width mt-2 mb-2 d-flex align-items-center" type="button" data-bs-toggle="collapse"
             data-bs-target="#add_steps_div_{{ section.id }}">
-        + add steps
+        <span class="d-flex justify-content-center flex-grow-1"> + add steps</span>
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-compact-down ms-auto" viewBox="0 0 16 16">
+            <path fill-rule="evenodd" d="M1.553 6.776a.5.5 0 0 1 .67-.223L8 9.44l5.776-2.888a.5.5 0 1 1 .448.894l-6 3a.5.5 0 0 1-.448 0l-6-3a.5.5 0 0 1-.223-.67"/>
+          </svg>
     </button>
 
     <div id="add_steps_div_{{ section.id }}" class="collapse">


### PR DESCRIPTION
## Description
In order to make the editing of steps easier and prevent automatic collapsing of all sections except for the active one, this PR is adding code that tracks the current state of the accordion to the local storage.
Also changed the remove icon and right-aligned it
This is a possible version of how this could be done, please give feedback if you have a different idea.

## Changes
sidebar_section.html
runs.js

## Testing
test by going trough different workflows and using the sidebar
local storage can be seen by entering inspection mode via "Application"

## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The code has been formatted with `black`
 
**Code review**
- [ ] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
