### PR TITLE
Add ARM support for install scripts

### DIFF
--- a/install_scripts/install_unix.sh
+++ b/install_scripts/install_unix.sh
@@ -14,6 +14,8 @@ if [ "$(uname -m)" == "x86_64" ]; then
   ARCHITECTURE_TO_USE="x86_64"
 elif [ "$(uname -m)" == "arm64" ]; then
   ARCHITECTURE_TO_USE="arm64"
+elif [ "$(uname -m)" == "aarch64" ]; then
+  ARCHITECTURE_TO_USE="aarch64"
 else
   echo "Architecture not supported."
   exit 1

--- a/install_scripts/install_unix.sh
+++ b/install_scripts/install_unix.sh
@@ -2,32 +2,47 @@
 
 ENV_NAME="protzilla"
 CONDA_URL="https://repo.anaconda.com/miniconda/"
-MACOS_MINICONDA="Miniconda3-latest-MacOSX-x86_64.sh"
-LINUX_MINICONDA="Miniconda3-latest-Linux-x86_64.sh"
+MINICONDA_PREFIX="Miniconda3-latest-"
+
 URL_TO_USE=""
-VERSION_TO_USE=""
+SCRIPT_NAME=""
+OS_TO_USE=""
+ARCHITECTURE_TO_USE=""
+
+# check the processor architecture
+if [ "$(uname -m)" == "x86_64" ]; then
+  ARCHITECTURE_TO_USE="x86_64"
+elif [ "$(uname -m)" == "arm64" ]; then
+  ARCHITECTURE_TO_USE="arm64"
+else
+  echo "Architecture not supported."
+  exit 1
+fi
 
 # check if the script is running on macos or linux
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-  URL_TO_USE=$CONDA_URL$LINUX_MINICONDA
-  VERSION_TO_USE=$LINUX_MINICONDA
+  OS_TO_USE="Linux"
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-  URL_TO_USE=$CONDA_URL$MACOS_MINICONDA
-  VERSION_TO_USE=$MACOS_MINICONDA
+  OS_TO_USE="MacOSX"
 else
   echo "OS not supported, use the install_windows.sh script (to be written)."
   exit 1
 fi
 
+SCRIPT_NAME="$MINICONDA_PREFIX$OS_TO_USE-$ARCHITECTURE_TO_USE.sh"
+URL_TO_USE="$CONDA_URL$SCRIPT_NAME"
+echo "Downloading $URL_TO_USE"
+
 # Check if some sort of conda is already installed
-if [ -d "$HOME/miniconda3" ] || [ -d "$HOME/miniconda" ] || [ -d "$HOME/anaconda3" ] || [ -d "$HOME/anaconda" ]; then
+if [ -d "$HOME/miniconda3" ] || [ -d "$HOME/miniconda" ] || [ -d "$HOME/anaconda3" ] || [ -d "$HOME/anaconda" ] || command -v conda >/dev/null 2>&1; then
+
   echo "Miniconda or Anaconda are already installed."
   conda init bash
 else
   echo "Installing Miniconda..."
   echo "$URL_TO_USE"
   curl -O $URL_TO_USE
-  bash $VERSION_TO_USE -p "$HOME"/miniconda
+  bash $SCRIPT_NAME -p "$HOME"/miniconda
   export PATH="$HOME/miniconda/bin:$PATH"
   source $HOME/miniconda/bin/activate
   conda config --set auto_activate_base false


### PR DESCRIPTION
## Description
fixes #545 
Adds support for ARM on Mac. There are also new snapdragon X series chips with risc-based architecture, but there seems to be no Miniconda support for it on windows. Also added the aarch64 linux-version of ARM.  

## Changes
`install_scripts/install_unix.sh`


## Testing
Please test the install_unix.sh script directly if you have OS - Architecture version not yet tested.

- [x] MacOS ARM (m1,m2,..)
- [ ] MacOS x86 (intel)
- [ ] Linux ARM (you should know when you have that)
- [ ] Linux x86

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The code has been formatted with `black`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
