### PR TITLE
changes list conversion to avoid numpy yaml error

### DIFF
--- a/protzilla/data_preprocessing/outlier_detection.py
+++ b/protzilla/data_preprocessing/outlier_detection.py
@@ -240,7 +240,7 @@ def by_pca(
             peptide_df=peptide_df,
             outlier_list=outlier_list,
             pca_df=df_transformed_pca_data,
-            explained_variance_ratio=list(pca_model.explained_variance_ratio_),
+            explained_variance_ratio=(pca_model.explained_variance_ratio_).tolist(),
             number_of_components=number_of_components,
         )
     except ValueError as e:


### PR DESCRIPTION
## Description
Bugfix for yaml-numpy.core.multiarray.scalar-error that prevents working with workflows that involve PCA step.

## Changes
tolist() changes the way the yaml saves the explained_variance_ratio and is therefore interpretable by yaml library


## Testing
May be tested by creating workflows that involve PCA and then change values, reopen, etc.

## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The code has been formatted with `black`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
