### PR TITLE
Fixing tests regarding non-availability of BioMart database

### DIFF
--- a/protzilla/data_integration/database_query.py
+++ b/protzilla/data_integration/database_query.py
@@ -94,6 +94,7 @@ def uniprot_columns(filename):
 def biomart_database(
     database_name: str = "ENSEMBL_MART_ENSEMBL", max_attempts: int = 3
 ):
+    # This method needs to be adjusted
     mirror_list = [
         "http://ensembl.org/biomart",
         "http://asia.ensembl.org/biomart",

--- a/protzilla/data_integration/database_query.py
+++ b/protzilla/data_integration/database_query.py
@@ -1,4 +1,4 @@
-from xml.etree.ElementTree import Element, SubElement, tostring
+from xml.etree.ElementTree import Element, SubElement, tostring, ParseError
 
 import pandas as pd
 import requests
@@ -107,8 +107,12 @@ def biomart_database(
                 if server:
                     db = server.databases[database_name]
                     return db
-
+            except ParseError as e:
+                if "Service unavailable" in str(e):
+                    print(f"ParseError: Expected XML but received an HTML error page indicating the service at {url} is unavailable.")
+                    continue
             except requests.ConnectionError:
+                print(f"ConnectionError: Could not connect to {url}.")
                 continue
 
 

--- a/protzilla/data_integration/database_query.py
+++ b/protzilla/data_integration/database_query.py
@@ -3,6 +3,7 @@ from xml.etree.ElementTree import Element, SubElement, tostring, ParseError
 import pandas as pd
 import requests
 from requests import HTTPError
+import warnings
 
 from biomart import BiomartServer
 
@@ -93,7 +94,10 @@ def uniprot_columns(filename):
     ).columns.tolist()
 
 
-def is_biomart_available(database_name: str="ENSEMBL_MART_ENSEMBL", max_attempts: int=3):
+def is_biomart_available(
+        database_name: str="ENSEMBL_MART_ENSEMBL",
+        max_attempts: int=3
+    ) -> bool:
     mirror_list = [
         "http://ensembl.org/biomart",
         "http://asia.ensembl.org/biomart",
@@ -108,13 +112,13 @@ def is_biomart_available(database_name: str="ENSEMBL_MART_ENSEMBL", max_attempts
                     return True
             except ParseError as e:
                 if "Service unavailable" in str(e):
-                    print(f"ParseError: Expected XML but received an HTML error page indicating the service at {url} is unavailable.")
+                    warnings.warn(f"ParseError: Expected XML but received an HTML error page indicating the service at {url} is unavailable.", RuntimeWarning)
                     continue
             except HTTPError as e:
-                print(f"HTTPError: Server at {url} responded with {e.response.status_code} {e.response.reason}.")
+                warnings.warn(f"HTTPError: Server at {url} responded with {e.response.status_code} {e.response.reason}.", RuntimeWarning)
                 continue
             except requests.ConnectionError:
-                print(f"ConnectionError: Could not connect to {url}.")
+                warnings.warn(f"ConnectionError: Could not connect to {url}.", RuntimeWarning)
                 continue
     return False
 
@@ -130,9 +134,8 @@ def biomart_database(
         for _ in range(max_attempts):
             for url in mirror_list:
                 server = BiomartServer(url)
-                if server:
-                    db = server.databases[database_name]
-                    return db
+                db = server.databases[database_name]
+                return db
 
 
 def uniprot_databases():

--- a/protzilla/data_integration/database_query.py
+++ b/protzilla/data_integration/database_query.py
@@ -2,6 +2,8 @@ from xml.etree.ElementTree import Element, SubElement, tostring, ParseError
 
 import pandas as pd
 import requests
+from requests import HTTPError
+
 from biomart import BiomartServer
 
 from protzilla.constants.paths import EXTERNAL_DATA_PATH
@@ -91,10 +93,7 @@ def uniprot_columns(filename):
     ).columns.tolist()
 
 
-def biomart_database(
-    database_name: str = "ENSEMBL_MART_ENSEMBL", max_attempts: int = 3
-):
-    # This method needs to be adjusted
+def is_biomart_available(database_name: str="ENSEMBL_MART_ENSEMBL", max_attempts: int=3):
     mirror_list = [
         "http://ensembl.org/biomart",
         "http://asia.ensembl.org/biomart",
@@ -106,14 +105,34 @@ def biomart_database(
                 server = BiomartServer(url)
                 if server:
                     db = server.databases[database_name]
-                    return db
+                    return True
             except ParseError as e:
                 if "Service unavailable" in str(e):
                     print(f"ParseError: Expected XML but received an HTML error page indicating the service at {url} is unavailable.")
                     continue
+            except HTTPError as e:
+                print(f"HTTPError: Server at {url} responded with {e.response.status_code} {e.response.reason}.")
+                continue
             except requests.ConnectionError:
                 print(f"ConnectionError: Could not connect to {url}.")
                 continue
+    return False
+
+def biomart_database(
+    database_name: str = "ENSEMBL_MART_ENSEMBL", max_attempts: int = 3
+):
+    mirror_list = [
+        "http://ensembl.org/biomart",
+        "http://asia.ensembl.org/biomart",
+        "http://useast.ensembl.org/biomart",
+    ]
+    if is_biomart_available():
+        for _ in range(max_attempts):
+            for url in mirror_list:
+                server = BiomartServer(url)
+                if server:
+                    db = server.databases[database_name]
+                    return db
 
 
 def uniprot_databases():

--- a/protzilla/data_integration/database_query.py
+++ b/protzilla/data_integration/database_query.py
@@ -107,9 +107,8 @@ def is_biomart_available(
         for url in mirror_list:
             try:
                 server = BiomartServer(url)
-                if server:
-                    db = server.databases[database_name]
-                    return True
+                db = server.databases[database_name]
+                return True
             except ParseError as e:
                 if "Service unavailable" in str(e):
                     warnings.warn(f"ParseError: Expected XML but received an HTML error page indicating the service at {url} is unavailable.", RuntimeWarning)

--- a/tests/protzilla/data_integration/test_enrichment_analysis.py
+++ b/tests/protzilla/data_integration/test_enrichment_analysis.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import patch
 
 import time
@@ -28,8 +29,11 @@ from protzilla.data_integration.enrichment_analysis_gsea import (
     gsea_preranked,
     create_ranked_df,
 )
+from protzilla.data_integration.database_query import is_biomart_available
 
 # isort:end_skip_file
+
+biomart_availability = is_biomart_available()
 
 
 @pytest.fixture
@@ -377,6 +381,8 @@ def test_GO_analysis_with_STRING_too_many_col_df():
 
 
 def test_GO_analysis_with_enrichr_wrong_proteins_input():
+    if biomart_availability == False:
+        pytest.skip("BioMart servers are not available. Skipping related tests.")
     current_out = GO_analysis_with_Enrichr(
         proteins_df="Protein1;Protein2;aStringOfProteins",
         organism="human",
@@ -393,6 +399,8 @@ def test_GO_analysis_with_enrichr_wrong_proteins_input():
 
 
 def test_GO_analysis_with_enrichr_wrong_gene_sets_input():
+    if biomart_availability == False:
+        pytest.skip("BioMart servers are not available. Skipping related tests.")
     current_out = GO_analysis_with_Enrichr(
         proteins_df=pd.DataFrame(
             {"Protein ID": ["Protein1"], "log2_fold_change": [1.0]}
@@ -406,6 +414,8 @@ def test_GO_analysis_with_enrichr_wrong_gene_sets_input():
 
 
 def test_GO_analysis_with_no_gene_sets_input():
+    if biomart_availability == False:
+        pytest.skip("BioMart servers are not available. Skipping related tests.")
     current_out = GO_analysis_with_Enrichr(
         proteins_df=pd.DataFrame(
             {"Protein ID": ["Protein1"], "log2_fold_change": [1.0]}
@@ -422,7 +432,9 @@ def test_GO_analysis_with_no_gene_sets_input():
 
 
 @patch("protzilla.data_integration.database_query.uniprot_groups_to_genes")
-def test_GO_analysis_with_Enrichr(mock_gene_mapping, data_folder_tests):
+def test_GO_analysis_with_Enrichr(mock_uniprot_groups_to_gene, data_folder_tests):
+    if biomart_availability == False:
+        pytest.skip("BioMart servers are not available. Skipping related tests.")
     # Check if enrichr API is available
     api_url = "https://maayanlab.cloud/Enrichr/addList"
     try:
@@ -500,6 +512,8 @@ def test_GO_analysis_with_Enrichr(mock_gene_mapping, data_folder_tests):
 
 
 def test_GO_analysis_Enrichr_wrong_background_file(data_folder_tests):
+    if biomart_availability == False:
+        pytest.skip("BioMart servers are not available. Skipping related tests.")
     current_out = GO_analysis_with_Enrichr(
         proteins_df=pd.DataFrame(
             {"Protein ID": ["Protein1"], "log2_fold_change": [1.0]}


### PR DESCRIPTION
## Description
fixes #563
This PR adds a method `is_biomart_available` which checks for an `ConnectionError`, `HTTPError` or `ParseError` when requesting data from the BioMart database. (A `ParseError` occurs when the biomart package expects an XML containing information on the server unavailability, but instead it gets a HTML file.) If the server is currently unavailable, these tests get skipped.

## Changes
Added new method to `data_integration/database_query.py` and changed the database query
Added availability checks to all test cases in `tests/protzilla/data_integration/test_enrichment_analysis.py` that are dependent on data from the BioMart database


## Testing

## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The code has been formatted with `black`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
