### PR TITLE
Removes unused import that keeps PROTzilla from launching

### DIFF
--- a/ui/runs/views.py
+++ b/ui/runs/views.py
@@ -43,7 +43,7 @@ from ui.runs.fields import (
     make_sidebar,
 )
 
-from ui.runs.views_helper import display_message, display_messages, parameters_from_post, get_filtered_data, set_filtered_data
+from ui.runs.views_helper import display_message, display_messages, get_filtered_data, set_filtered_data
 
 from .form_mapping import (
     get_filled_form_by_method,


### PR DESCRIPTION
Somehow there was an unused import of a function that is not existent anymore, so upon launch there was an ImportError :(

I just removed the import